### PR TITLE
Add Shortcut integration with smart ticket templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ INTERCOM_ACCESS_TOKEN=your_intercom_token_here
 
 # Shortcut (MCP: npx -y @shortcut/mcp@latest)
 SHORTCUT_API_TOKEN=
+SHORTCUT_BACKLOG_STATE_ID=
+SHORTCUT_DONE_STATE_ID=
 
 # LLM Classification (OpenAI)
 OPENAI_API_KEY=


### PR DESCRIPTION
## Summary

- Wire up ShortcutClient to create tickets when themes reach threshold
- Add two ticket templates (bug vs trend) with appropriate structure
- Add user metadata to excerpts with clickable deep links
- Add repro step and media link detection for better excerpt prioritization

## Changes

### Shortcut Integration (`src/shortcut_client.py`)
- Add `workflow_state_id` parameter for story creation
- Read `SHORTCUT_BACKLOG_STATE_ID` and `SHORTCUT_DONE_STATE_ID` from env

### Smart Ticket Templates (`src/theme_tracker.py`)
- `get_theme_type()` categorizes themes as 'bug' or 'trend'
- **Bug template**: Steps to reproduce, acceptance criteria, investigation points
- **Trend template**: Volume summary, patterns, suggested actions (FAQ, self-service)

### User Metadata in Excerpts
- Intercom conversation link (uses `INTERCOM_APP_ID`)
- Jarvis org link: `https://jarvis.tailwind.ai/organizations/{org_id}`
- Jarvis user link: `https://jarvis.tailwind.ai/organizations/{org_id}/users/{user_id}`

### Excerpt Scoring Improvements
- **Repro step detection** (+15 per indicator, max +50): numbered lists, sequential words, UI/form actions
- **Media link detection** (+30 per link): Loom, Jam, CleanShot, Imgur, YouTube, direct image URLs
- Media links extracted and displayed prominently in ticket excerpts

## Test Plan

- [x] Tested Shortcut API connection and story creation
- [x] Verified workflow state ID configuration
- [x] Created test tickets with both templates (bug and trend)
- [x] Tested repro step scoring with various excerpt patterns
- [x] Tested media link extraction for Loom, Jam, Imgur, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)