### PR TITLE
Add story-tracking web app architecture and reference from PLAN

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -22,6 +22,7 @@ Product teams are drowning in support conversations. Valuable signals—feature 
 
 - **Primary consumers**: Product and Engineering teams at the organization
 - **Output format**: Actionable tickets in Shortcut (the organization's issue tracker)
+- **System-of-record roadmap**: Architecture for a dedicated story-tracking web app with bidirectional Shortcut sync is captured in `docs/story-tracking-web-app-architecture.md`.
 - **Scale**: ~50-150 Intercom conversations per week
 
 ---

--- a/docs/story-tracking-web-app-architecture.md
+++ b/docs/story-tracking-web-app-architecture.md
@@ -1,0 +1,269 @@
+# Story Tracking Web App Architecture (System of Record)
+
+## Summary
+This document defines the full architecture for the story tracking web app that becomes the **system of record**, while maintaining **bidirectional Shortcut sync**. The system remains **lifecycle-agnostic** for now, treats Shortcut as a downstream/upstream sync target, and supports richer internal metadata (e.g., evidence, conversation counts).
+
+### Decisions captured
+- **Lifecycle:** agnostic (no hardcoded workflow state machine).
+- **Sync fields:** title, description, comments, labels, priority, severity, product area, technical area.
+- **Conflict policy:** last-write-wins (across all bidirectional fields).
+- **Labels:** must include production Shortcut taxonomy; may expand internally.
+- **Product/technical area:** stored as Shortcut enum values for clean mapping.
+
+---
+
+## Goals & non-goals
+### Goals
+- Internal web app is the canonical system of record for stories, evidence, and tracking.
+- Shortcut stays in sync bidirectionally for shared fields.
+- UI can support richer internal metadata than Shortcut can represent.
+
+### Non-goals (for now)
+- No role-based UI/permissions.
+- No enforced lifecycle/state machine.
+
+---
+
+## Architecture overview
+```
+Pipeline -> Candidate Stories -> Story Service (canonical)
+                                   |     |
+                                   |     v
+                                   |  Evidence Service
+                                   v
+                           Shortcut Sync Service <-> Shortcut API
+```
+
+### Key services (logical)
+1. **Story Service**: canonical story state and metadata.
+2. **Evidence Service**: evidence bundles, conversation links, source stats.
+3. **Sync Service**: bidirectional sync with Shortcut, conflict resolution.
+4. **Label Registry**: Shortcut taxonomy + internal extensions.
+5. **Analytics Service**: aggregate metrics and trends.
+
+---
+
+## Canonical data model
+### 1) `stories`
+Canonical work items stored internally. All Shortcut-shared fields are stored with Shortcut-compatible values.
+
+**Fields**
+- `id` (pk)
+- `title`
+- `description`
+- `comments` (JSON array of objects with `id`, `source`, `body`, `created_at`)
+- `labels` (array of strings)
+- `priority` (Shortcut enum value)
+- `severity` (Shortcut enum value)
+- `product_area` (Shortcut enum value)
+- `technical_area` (Shortcut enum value)
+- `status` (free-form string)
+- `confidence_score`
+- `evidence_count`
+- `conversation_count`
+- `created_at`, `updated_at`
+
+**Notes**
+- `priority`, `severity`, `product_area`, `technical_area` store Shortcut enum values directly.
+- `labels` must include production Shortcut taxonomy values, plus internal extensions.
+
+### 2) `story_evidence`
+Evidence bundles that ground a story in sources and themes.
+
+**Fields**
+- `story_id` (fk)
+- `conversation_ids` (array)
+- `theme_signatures` (array)
+- `source_stats` (JSON)
+- `excerpts` (array)
+- `last_updated`
+
+### 3) `story_sync_metadata`
+Sync bookkeeping for Shortcut.
+
+**Fields**
+- `story_id` (fk)
+- `shortcut_story_id`
+- `last_internal_update_at`
+- `last_external_update_at`
+- `last_synced_at`
+- `last_sync_status`
+- `last_sync_error`
+
+### 4) `label_registry`
+Tracks Shortcut taxonomy labels and internal extensions.
+
+**Fields**
+- `label_name`
+- `source` (shortcut/internal)
+- `created_at`
+- `last_seen_at`
+
+---
+
+## UI surface (mapped to the data model)
+### Board view (Kanban-like)
+- Backed by `stories.status`.
+- Quick metadata: `conversation_count`, `evidence_count`, `confidence_score`, `labels`, `priority`.
+
+### Story detail view
+- Story fields + evidence bundle.
+- Tabs: Evidence, Themes, Sync, History.
+
+### Analytics view
+- Aggregates on `stories` and `story_evidence` (top stories by evidence, source distribution, trends).
+
+---
+
+## Bidirectional Shortcut sync
+### Shared fields (bidirectional)
+- Title
+- Description
+- Comments
+- Labels
+- Priority
+- Severity
+- Product Area
+- Technical Area
+
+### Conflict policy
+**Last-write-wins** across all bidirectional fields.
+
+### Sync metadata
+- Track `last_internal_update_at`, `last_external_update_at`, `last_synced_at` for comparisons.
+
+### Comments behavior
+- Store comments with `(comment_id, source)` to avoid duplicates.
+
+### Labels behavior
+- Maintain a label registry seeded from Shortcut.
+- Internal labels can be added and must be created in Shortcut during sync.
+
+---
+
+## Sync algorithm (last-write-wins)
+```
+if last_internal_update_at > last_external_update_at:
+    push internal -> Shortcut
+else:
+    pull Shortcut -> internal
+```
+
+- On success, update `last_synced_at` and `last_sync_status`.
+- On failure, record `last_sync_error` and retry with backoff.
+
+---
+
+## Sync API (draft)
+### 1) Push internal -> Shortcut
+`POST /sync/shortcut/push`
+
+**Request**
+```
+{
+  "story_id": "...",
+  "snapshot": {
+    "title": "...",
+    "description": "...",
+    "comments": [ ... ],
+    "labels": ["..."] ,
+    "priority": "...",
+    "severity": "...",
+    "product_area": "...",
+    "technical_area": "..."
+  },
+  "last_internal_update_at": "..."
+}
+```
+
+**Response**
+```
+{
+  "shortcut_story_id": "...",
+  "last_synced_at": "...",
+  "sync_status": "success"
+}
+```
+
+### 2) Pull Shortcut -> internal
+`POST /sync/shortcut/pull`
+
+**Request**
+```
+{
+  "shortcut_story_id": "...",
+  "last_external_update_at": "..."
+}
+```
+
+**Response**
+```
+{
+  "story_id": "...",
+  "snapshot": { ... },
+  "last_synced_at": "...",
+  "sync_status": "success"
+}
+```
+
+### 3) Shortcut webhook (optional)
+`POST /sync/shortcut/webhook`
+
+**Payload**
+```
+{
+  "shortcut_story_id": "...",
+  "event_type": "story.updated",
+  "updated_at": "...",
+  "fields": { ... }
+}
+```
+
+### 4) Sync status
+`GET /sync/shortcut/status/:story_id`
+
+**Response**
+```
+{
+  "story_id": "...",
+  "shortcut_story_id": "...",
+  "last_internal_update_at": "...",
+  "last_external_update_at": "...",
+  "last_synced_at": "...",
+  "last_sync_status": "...",
+  "last_sync_error": "..."
+}
+```
+
+---
+
+## Label taxonomy import
+- A one-time import job pulls the production Shortcut label taxonomy into `label_registry`.
+- A periodic refresh (or on-demand action) keeps the registry aligned with Shortcut.
+- New internal labels are created in Shortcut during sync.
+
+---
+
+## Pre-implementation planning checklist
+- **Shortcut taxonomy snapshot:** export the production labels/product areas/technical areas, store a vetted snapshot for local dev and tests, and define how often it is refreshed.
+- **Sync surface audit:** confirm Shortcut field limits (label count, comment sizes) and decide how to handle overflows or truncation.
+- **Event sourcing vs. polling:** decide whether to rely on Shortcut webhooks, scheduled polling, or a hybrid (including expected latency targets).
+- **Data ownership matrix:** document which internal fields are canonical and which are Shortcut-shared, even under last-write-wins.
+- **Backfill strategy:** define how existing Shortcut stories will be imported into the new schema and how duplicates will be detected.
+- **Operational SLIs/SLOs:** outline metrics to track sync freshness, error rates, and drift between systems.
+- **Security/credential handling:** decide where Shortcut API credentials live and how access is audited/rotated.
+
+---
+
+## Open implementation questions
+- Where the sync event queue lives (DB, task queue, or worker service).
+- Whether we need a hard limit on free-form label creation.
+- How to store `comments` (JSON in `stories` vs. separate `story_comments` table).
+
+---
+
+## Rollout plan (MVP -> full)
+1. **Read-only UI** with story + evidence views.
+2. **Editable story fields** in UI.
+3. **Bidirectional Shortcut sync** with last-write-wins.
+4. **Analytics enhancements** and reliability hardening.


### PR DESCRIPTION
### Motivation
- Capture a system-of-record roadmap for story tracking with bidirectional Shortcut sync as part of the project plan.
- Provide a canonical internal data model and sync policy to reduce ambiguity during implementation.
- Surface pre-implementation tasks (taxonomy snapshot, sync audit, backfill strategy, credentials) needed before development starts.
- Clarify the sync surface and API contract to guide engineering on bidirectional behavior and conflict resolution.

### Description
- Add `docs/story-tracking-web-app-architecture.md` describing the architecture, services, canonical data model, UI surfaces, and analytics intent.
- Document bidirectional Shortcut sync including shared fields, conflict policy (`last-write-wins`), sync bookkeeping, and a draft sync API (`POST /sync/shortcut/push`, `POST /sync/shortcut/pull`).
- Include a pre-implementation planning checklist covering `Shortcut taxonomy snapshot`, `Sync surface audit`, `Event sourcing vs. polling`, `Backfill strategy`, `Operational SLIs/SLOs`, and `Security/credential handling`.
- Update `PLAN.md` to reference the new architecture doc as the `System-of-record roadmap`.

### Testing
- This is a documentation-only change and did not modify executable code.
- No automated tests were executed for this change. 
- No test failures occurred because no tests were run. 
- Documentation was linted by review (implicit) rather than automated tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69613d06f2cc832f860a70c0fc445830)