### PR TITLE
feat(api): Add accept/reject endpoints for suggested evidence

### DIFF
--- a/src/research/models.py
+++ b/src/research/models.py
@@ -188,3 +188,12 @@ class ReindexResponse(BaseModel):
     items_failed: int = 0
     duration_seconds: Optional[float] = None
     error: Optional[str] = None
+
+
+class EvidenceDecisionResponse(BaseModel):
+    """Response for evidence accept/reject operations."""
+
+    success: bool = Field(..., description="Whether the operation succeeded")
+    story_id: str = Field(..., description="Story ID the decision applies to")
+    evidence_id: str = Field(..., description="Evidence ID that was accepted/rejected")
+    decision: Literal["accepted", "rejected"] = Field(..., description="The decision made")


### PR DESCRIPTION
## Summary

Implements GitHub Issue #49: Evidence Accept/Reject API Endpoints

- Adds `POST /api/research/stories/{story_id}/suggested-evidence/{evidence_id}/accept`
- Adds `POST /api/research/stories/{story_id}/suggested-evidence/{evidence_id}/reject`
- Validates evidence_id format and source_type against allowed values
- Returns proper HTTP status codes (200, 400, 404, 409)
- Uses psycopg2 IntegrityError for database constraint handling

## Test plan

- [x] 15 new unit tests added (47 total in test_research.py)
- [x] All tests pass: `pytest tests/test_research.py -v`
- [x] Build passes: `pytest tests/ -v`
- [ ] Manual verification with real database (optional)

## Review

5-personality review converged after 2 rounds:
- Round 1: 4 MAJOR issues identified (transaction handling, exception handling, URL consistency)
- Round 2: All issues resolved or accepted

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)