### PR TITLE
feat(search): Filter previously rejected evidence from suggestions

### DIFF
--- a/src/api/routers/research.py
+++ b/src/api/routers/research.py
@@ -281,6 +281,17 @@ def get_suggested_evidence(
         max_suggestions=limit,
     )
 
+    # Get previously rejected evidence IDs for this story
+    with db.cursor() as cur:
+        cur.execute("""
+            SELECT evidence_id FROM suggested_evidence_decisions
+            WHERE story_id = %s AND decision = 'rejected'
+        """, (str(story_id),))
+        rejected_ids = {row["evidence_id"] for row in cur.fetchall()}
+
+    # Filter out rejected suggestions
+    results = [r for r in results if f"{r.source_type}:{r.source_id}" not in rejected_ids]
+
     # Convert to SuggestedEvidence format
     suggestions = [
         SuggestedEvidence(


### PR DESCRIPTION
## Summary

Implements GitHub Issue #50: Filter rejected evidence from suggestions

When retrieving suggested evidence for a story, previously rejected evidence is now excluded from the results.

- Queries `suggested_evidence_decisions` table for rejected evidence IDs
- Filters results before converting to response format
- Uses existing composite index `idx_evidence_decisions_story_decision` for efficient lookup

## Dependencies

- **Depends on PR #57** (#49 - accept/reject endpoints)
- Builds on PR #52 (#48 - schema migration)

## Test plan

- [x] 3 new tests added (50 total in test_research.py)
- [x] All tests pass: `pytest tests/test_research.py -v`
- [x] `test_suggested_evidence_filters_rejected` - verifies filtering works
- [x] `test_suggested_evidence_returns_accepted` - verifies accepted is NOT filtered
- [x] `test_suggested_evidence_no_rejections_returns_all` - regression test

## Review

5-personality review converged in 1 round - all reviewers passed.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)