### PR TITLE
fix: Recover orphaned changes from PRs #58 and #59

### DIFF
--- a/docs/runbook/vector-search-setup.md
+++ b/docs/runbook/vector-search-setup.md
@@ -1,0 +1,239 @@
+# Vector Search Setup Runbook
+
+Manual setup steps for FeedForward's vector search infrastructure.
+
+## Prerequisites
+
+- PostgreSQL 13+ with superuser access
+- Python 3.10+
+- OpenAI API key with embedding model access
+- Database connection configured in `.env`
+
+## Step 1: Install pgvector Extension
+
+### Option A: Local Development (macOS)
+
+```bash
+# Install via Homebrew
+brew install pgvector
+
+# Connect to your database
+psql -d feedforward
+
+# Enable the extension
+CREATE EXTENSION vector;
+```
+
+### Option B: Docker
+
+```bash
+# Use pgvector-enabled image
+docker pull ankane/pgvector
+
+# Or add to existing Postgres container
+docker exec -it postgres psql -U postgres -d feedforward -c "CREATE EXTENSION vector;"
+```
+
+### Option C: Cloud (Supabase, Neon, etc.)
+
+Most managed PostgreSQL services include pgvector. Enable via dashboard or:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+### Verify Installation
+
+```sql
+SELECT * FROM pg_extension WHERE extname = 'vector';
+-- Should return one row
+```
+
+## Step 2: Apply Database Migration
+
+The migration creates the `research_embeddings` table with vector index.
+
+```bash
+# Apply migration
+psql -d feedforward -f src/db/migrations/001_add_research_embeddings.sql
+```
+
+### Verify Table Exists
+
+```sql
+SELECT COUNT(*) FROM research_embeddings;
+-- Should return 0 (empty table)
+```
+
+## Step 3: Configure Environment
+
+Ensure `.env` contains:
+
+```bash
+# Database
+DATABASE_URL=postgresql://user:pass@localhost:5432/feedforward
+
+# OpenAI (for embedding generation)
+OPENAI_API_KEY=sk-...
+```
+
+## Step 4: Run Initial Embeddings
+
+Use the setup script:
+
+```bash
+# Full run (all sources)
+python scripts/run_initial_embeddings.py
+
+# Test with limited data first
+python scripts/run_initial_embeddings.py --limit 10
+
+# Verify setup only (no embedding generation)
+python scripts/run_initial_embeddings.py --skip-embeddings
+```
+
+### Expected Output
+
+```
+Verifying pgvector extension...
+✓ pgvector extension verified
+
+Checking research_embeddings table...
+✓ research_embeddings table exists
+
+Running embedding pipeline...
+  Status: completed
+  Processed: 1250
+  Updated: 1250
+  Failed: 0
+  Duration: 45.23s
+
+Embedding Counts:
+  coda_page: 500
+  coda_theme: 250
+  intercom: 500
+  Total: 1250
+
+Running 10 search queries...
+  'pin not posting...' - 120ms
+  'scheduling issues...' - 95ms
+  ...
+
+Performance Results:
+  Queries: 10/10
+  Average: 115ms
+  P95: 180ms
+  ✓ P95 within 500ms target
+
+========================================
+✓ Vector search setup complete!
+========================================
+```
+
+## Step 5: Verify Search Works
+
+Test via API:
+
+```bash
+curl -X GET "http://localhost:8000/api/research/search?q=pin+not+posting&limit=5"
+```
+
+Or via Python:
+
+```python
+from src.research.unified_search import UnifiedSearchService
+
+service = UnifiedSearchService()
+results = service.search(query="pin not posting", limit=5)
+for r in results:
+    print(f"{r.similarity:.2f} - {r.title}")
+```
+
+## Troubleshooting
+
+### pgvector Extension Not Found
+
+```
+ERROR: extension "vector" is not available
+```
+
+**Fix**: Install pgvector binary (see Step 1).
+
+### Migration Failed
+
+```
+ERROR: relation "research_embeddings" already exists
+```
+
+**Fix**: Table already created. Skip migration or drop and re-create:
+
+```sql
+DROP TABLE IF EXISTS research_embeddings;
+```
+
+### OpenAI API Error
+
+```
+ERROR: Batch embedding generation failed: AuthenticationError
+```
+
+**Fix**: Verify `OPENAI_API_KEY` in `.env` is valid.
+
+### P95 Latency > 500ms
+
+Possible causes:
+
+1. **Cold cache**: Run 2-3 more query batches to warm up
+2. **Index not built**: Check HNSW index exists:
+   ```sql
+   SELECT indexname FROM pg_indexes WHERE tablename = 'research_embeddings';
+   ```
+3. **Too many vectors**: Consider increasing `m` and `ef_construction` parameters
+
+### No Embeddings Generated
+
+```
+Processed: 0, Updated: 0
+```
+
+Possible causes:
+
+1. **Empty source data**: Check Coda and Intercom data exists in database
+2. **Adapter error**: Run with `--verbose` flag for detailed logs
+3. **Network issue**: Check OpenAI API connectivity
+
+## Performance Targets
+
+| Metric               | Target       | Action if Exceeded                    |
+| -------------------- | ------------ | ------------------------------------- |
+| P95 Search Latency   | < 500ms      | Check HNSW index, optimize parameters |
+| Embedding Generation | < 100ms/item | Check OpenAI API tier limits          |
+| Total Embeddings     | > 100        | Verify source data exists             |
+
+## Maintenance
+
+### Re-index Changed Content
+
+```bash
+# Only re-embed changed content (default)
+python -m src.research.embedding_pipeline
+
+# Force re-embed everything
+python -m src.research.embedding_pipeline --force
+```
+
+### Monitor Embedding Counts
+
+```sql
+SELECT source_type, COUNT(*), MAX(updated_at)
+FROM research_embeddings
+GROUP BY source_type;
+```
+
+---
+
+## Related Documentation
+
+- [Architecture: Section 15 - Unified Research Search](../architecture.md#15-unified-research-search)
+- [API: Research Endpoints](../api-reference.md#research)
+- [Migration: 001_add_research_embeddings.sql](../../src/db/migrations/001_add_research_embeddings.sql)

--- a/scripts/run_initial_embeddings.py
+++ b/scripts/run_initial_embeddings.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+Setup and validation script for GitHub Issue #51.
+
+Verifies pgvector setup and runs initial embedding pipeline.
+Includes performance benchmarking for search queries.
+"""
+
+import argparse
+import logging
+import sys
+import time
+from pathlib import Path
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def setup_logging(verbose: bool = False) -> None:
+    """Configure logging."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+
+def verify_pgvector() -> bool:
+    """Check pgvector extension is installed."""
+    from src.db.connection import get_connection
+
+    try:
+        with get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT * FROM pg_extension WHERE extname = 'vector'")
+                if not cur.fetchone():
+                    print("❌ pgvector extension not installed")
+                    print("   Run: CREATE EXTENSION vector;")
+                    return False
+        print("✓ pgvector extension verified")
+        return True
+    except Exception as e:
+        print(f"❌ Failed to verify pgvector: {e}")
+        return False
+
+
+def check_migration_applied() -> bool:
+    """Check if research_embeddings table exists."""
+    from src.db.connection import get_connection
+
+    try:
+        with get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT EXISTS (
+                        SELECT FROM information_schema.tables
+                        WHERE table_name = 'research_embeddings'
+                    )
+                """)
+                exists = cur.fetchone()[0]
+                if not exists:
+                    print("❌ research_embeddings table not found")
+                    print("   Apply migration: src/db/migrations/001_add_research_embeddings.sql")
+                    return False
+        print("✓ research_embeddings table exists")
+        return True
+    except Exception as e:
+        print(f"❌ Failed to check migration: {e}")
+        return False
+
+
+def run_embeddings(limit=None) -> bool:
+    """Run embedding pipeline with progress."""
+    from src.research.embedding_pipeline import run_embedding_pipeline
+
+    try:
+        print(f"\nRunning embedding pipeline{' (limit=' + str(limit) + ')' if limit else ''}...")
+        result = run_embedding_pipeline(limit=limit)
+
+        print(f"  Status: {result.status}")
+        print(f"  Sources: {', '.join(result.source_types)}")
+        print(f"  Processed: {result.items_processed}")
+        print(f"  Updated: {result.items_updated}")
+        print(f"  Failed: {result.items_failed}")
+        if result.duration_seconds:
+            print(f"  Duration: {result.duration_seconds:.2f}s")
+        if result.error:
+            print(f"  Error: {result.error}")
+            return False
+
+        if result.status == "completed":
+            print("✓ Embedding pipeline completed")
+            return True
+        else:
+            print(f"❌ Embedding pipeline failed: {result.status}")
+            return False
+    except Exception as e:
+        print(f"❌ Failed to run embeddings: {e}")
+        logging.exception("Embedding pipeline error")
+        return False
+
+
+def count_embeddings() -> int:
+    """Count embeddings by source type."""
+    from src.db.connection import get_connection
+
+    try:
+        with get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT source_type, COUNT(*)
+                    FROM research_embeddings
+                    GROUP BY source_type
+                    ORDER BY source_type
+                """)
+                rows = cur.fetchall()
+
+        print("\nEmbedding Counts:")
+        total = 0
+        if rows:
+            for source_type, count in rows:
+                print(f"  {source_type}: {count}")
+                total += count
+            print(f"  Total: {total}")
+        else:
+            print("  No embeddings found")
+
+        return total
+    except Exception as e:
+        print(f"❌ Failed to count embeddings: {e}")
+        return 0
+
+
+def measure_performance() -> bool:
+    """Run 10 search queries and report P95 latency."""
+    from src.research.unified_search import UnifiedSearchService
+
+    test_queries = [
+        "pin not posting",
+        "scheduling issues",
+        "account migration",
+        "payment failed",
+        "media upload error",
+        "timezone problems",
+        "hashtag suggestions",
+        "analytics dashboard",
+        "profile visibility",
+        "content moderation",
+    ]
+
+    try:
+        service = UnifiedSearchService()
+        latencies = []
+
+        print("\nRunning 10 search queries...")
+        for query in test_queries:
+            start = time.time()
+            try:
+                results = service.search(query=query, limit=5)
+                latency = (time.time() - start) * 1000  # ms
+                latencies.append(latency)
+                print(f"  '{query[:30]:<30}' - {latency:>6.0f}ms ({len(results)} results)")
+            except Exception as e:
+                print(f"  '{query[:30]:<30}' - FAILED: {e}")
+
+        if latencies:
+            latencies.sort()
+            p95_index = int(len(latencies) * 0.95)
+            p95 = latencies[min(p95_index, len(latencies) - 1)]
+            avg = sum(latencies) / len(latencies)
+            median = latencies[len(latencies) // 2]
+
+            print(f"\nPerformance Results:")
+            print(f"  Queries: {len(latencies)}/10 successful")
+            print(f"  Average: {avg:.0f}ms")
+            print(f"  Median:  {median:.0f}ms")
+            print(f"  P95:     {p95:.0f}ms")
+
+            if p95 > 500:
+                print(f"  ⚠️  P95 exceeds 500ms target (actual: {p95:.0f}ms)")
+                return False
+            else:
+                print(f"  ✓ P95 within 500ms target")
+                return True
+        else:
+            print("❌ No successful queries")
+            return False
+    except Exception as e:
+        print(f"❌ Failed to measure performance: {e}")
+        logging.exception("Performance measurement error")
+        return False
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Verify pgvector setup and run initial embedding pipeline"
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Limit items per source (for testing)",
+    )
+    parser.add_argument(
+        "--skip-embeddings",
+        action="store_true",
+        help="Skip running embeddings (just verify setup)",
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Verbose logging",
+    )
+
+    args = parser.parse_args()
+    setup_logging(args.verbose)
+
+    print("=" * 60)
+    print("pgvector Setup Validation & Initial Embedding Pipeline")
+    print("=" * 60)
+
+    # Step 1: Verify pgvector
+    print("\n[1/5] Verifying pgvector extension...")
+    if not verify_pgvector():
+        sys.exit(1)
+
+    # Step 2: Check migration
+    print("\n[2/5] Checking research_embeddings migration...")
+    if not check_migration_applied():
+        sys.exit(1)
+
+    # Step 3: Run embeddings (unless skipped)
+    if args.skip_embeddings:
+        print("\n[3/5] Skipping embedding pipeline (--skip-embeddings)")
+    else:
+        print("\n[3/5] Running embedding pipeline...")
+        if not run_embeddings(limit=args.limit):
+            sys.exit(1)
+
+    # Step 4: Count embeddings
+    print("\n[4/5] Counting embeddings...")
+    total = count_embeddings()
+    if total == 0:
+        print("⚠️  No embeddings found - did the pipeline run?")
+        if not args.skip_embeddings:
+            sys.exit(1)
+
+    # Step 5: Performance test
+    if total > 0:
+        print("\n[5/5] Measuring search performance...")
+        if not measure_performance():
+            print("⚠️  Performance test had issues, but setup is complete")
+    else:
+        print("\n[5/5] Skipping performance test (no embeddings)")
+
+    print("\n" + "=" * 60)
+    print("✓ Setup validation complete!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/routers/research.py
+++ b/src/api/routers/research.py
@@ -281,6 +281,17 @@ def get_suggested_evidence(
         max_suggestions=limit,
     )
 
+    # Get previously rejected evidence IDs for this story
+    with db.cursor() as cur:
+        cur.execute("""
+            SELECT evidence_id FROM suggested_evidence_decisions
+            WHERE story_id = %s AND decision = 'rejected'
+        """, (str(story_id),))
+        rejected_ids = {row["evidence_id"] for row in cur.fetchall()}
+
+    # Filter out rejected suggestions
+    results = [r for r in results if f"{r.source_type}:{r.source_id}" not in rejected_ids]
+
     # Convert to SuggestedEvidence format
     suggestions = [
         SuggestedEvidence(


### PR DESCRIPTION
## Summary
- PRs #58 and #59 were merged to feature branches that had already been merged to main, leaving their changes orphaned
- This PR recovers those changes and brings them to main

## Recovered Changes

**From PR #58 (Filter rejected evidence):**
- Filter previously rejected evidence from suggestions in research.py
- Add 3 tests for rejection filtering behavior

**From PR #59 (Vector search setup):**
- Add `scripts/run_initial_embeddings.py` validation script
- Add `docs/runbook/vector-search-setup.md` runbook

## Test plan
- [x] Tests pass: 50 tests in test_research.py
- [x] Cherry-picked commits verified against original PRs

Completes Vector Integration Phase 1 (issue #43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)