### PR TITLE
fix(research): Fix embedding model and missing URL column

### DIFF
--- a/src/db/migrations/001_add_research_embeddings.sql
+++ b/src/db/migrations/001_add_research_embeddings.sql
@@ -15,11 +15,12 @@ CREATE TABLE IF NOT EXISTS research_embeddings (
     content_hash TEXT NOT NULL,             -- SHA-256 hash for change detection
 
     -- Content
-    title TEXT,                             -- Display title
+    title TEXT NOT NULL,                    -- Display title
     content TEXT NOT NULL,                  -- Full text content for embedding
+    url TEXT NOT NULL,                      -- Link to original source
 
-    -- Vector embedding (OpenAI text-embedding-3-large = 1536 dimensions)
-    embedding vector(1536),
+    -- Vector embedding (OpenAI text-embedding-3-small = 1536 dimensions)
+    embedding vector(1536) NOT NULL,
 
     -- Metadata (source-specific fields)
     metadata JSONB DEFAULT '{}',            -- participant, tags, url, etc.
@@ -71,5 +72,5 @@ COMMENT ON TABLE research_embeddings IS 'Unified embeddings table for RAG/Search
 COMMENT ON COLUMN research_embeddings.source_type IS 'Data source: coda_page, coda_theme, intercom';
 COMMENT ON COLUMN research_embeddings.source_id IS 'Unique identifier within the source system';
 COMMENT ON COLUMN research_embeddings.content_hash IS 'SHA-256 hash of content for change detection';
-COMMENT ON COLUMN research_embeddings.embedding IS 'OpenAI text-embedding-3-large vector (1536 dims)';
+COMMENT ON COLUMN research_embeddings.embedding IS 'OpenAI text-embedding-3-small vector (1536 dims)';
 COMMENT ON COLUMN research_embeddings.metadata IS 'Source-specific metadata as JSONB';

--- a/src/research/embedding_pipeline.py
+++ b/src/research/embedding_pipeline.py
@@ -35,7 +35,7 @@ class EmbeddingPipeline:
 
     def __init__(
         self,
-        embedding_model: str = "text-embedding-3-large",
+        embedding_model: str = "text-embedding-3-small",
         embedding_dimensions: int = 1536,
         batch_size: int = 100,
         config_path: Optional[Path] = None,
@@ -62,7 +62,7 @@ class EmbeddingPipeline:
         """Load configuration from YAML file."""
         defaults = {
             "embedding": {
-                "model": "text-embedding-3-large",
+                "model": "text-embedding-3-small",
                 "dimensions": 1536,
                 "batch_size": 100,
             },
@@ -268,6 +268,7 @@ class EmbeddingPipeline:
                         content_hash,
                         item.title,
                         item.content,
+                        item.url,
                         embedding,
                         item.metadata,
                     ))
@@ -362,12 +363,13 @@ class EmbeddingPipeline:
             sql = """
                 INSERT INTO research_embeddings (
                     source_type, source_id, content_hash,
-                    title, content, embedding, metadata
+                    title, content, url, embedding, metadata
                 ) VALUES %s
                 ON CONFLICT (source_type, source_id) DO UPDATE SET
                     content_hash = EXCLUDED.content_hash,
                     title = EXCLUDED.title,
                     content = EXCLUDED.content,
+                    url = EXCLUDED.url,
                     embedding = EXCLUDED.embedding,
                     metadata = EXCLUDED.metadata,
                     updated_at = NOW()
@@ -381,10 +383,11 @@ class EmbeddingPipeline:
                     content_hash,
                     title,
                     content,
+                    url,
                     embedding,  # pgvector handles list conversion
                     Json(metadata) if metadata else None,
                 )
-                for source_type, source_id, content_hash, title, content, embedding, metadata in rows
+                for source_type, source_id, content_hash, title, content, url, embedding, metadata in rows
             ]
 
             execute_values(cur, sql, formatted_rows)

--- a/src/research/unified_search.py
+++ b/src/research/unified_search.py
@@ -49,7 +49,7 @@ class UnifiedSearchService:
 
     def __init__(
         self,
-        embedding_model: str = "text-embedding-3-large",
+        embedding_model: str = "text-embedding-3-small",
         embedding_dimensions: int = 1536,
         config_path: Optional[Path] = None,
     ):


### PR DESCRIPTION
## Summary
- Switch from text-embedding-3-large (3072 dims) to text-embedding-3-small (1536 dims) to stay within pgvector's 2000 dimension limit
- Add missing url column to INSERT statement in embedding_pipeline.py
- Update migration to include url column as NOT NULL

## Root Cause
- pgvector 0.8 has a 2000 dimension limit for both ivfflat and HNSW indexes
- The original code used text-embedding-3-large (3072 dims) which exceeds this limit
- The url field from SearchableContent was not being inserted into the database

## Test plan
- [x] Unit tests: 50 passing
- [x] Functional test: `python scripts/run_initial_embeddings.py --limit 5 -v`
  - ✓ pgvector extension verified
  - ✓ research_embeddings table exists
  - ✓ Embedding pipeline: 10 processed, 0 failed
  - ✓ Search performance test complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)