### PR TITLE
fix(research): Fix coda_page adapter SQL column mismatch

### DIFF
--- a/ralph/progress.txt
+++ b/ralph/progress.txt
@@ -1,0 +1,33 @@
+ITERATION: 0
+STATE:
+- Task not started.
+
+NEXT:
+- Read ralph/PROMPT.md and this file.
+- Begin with Hybrid Week 1, Issue #62.
+- Make the smallest shippable change and commit.
+
+---
+
+ITERATION: 1
+ISSUE: #62 fix(research): coda_page adapter fails with "no such column: name"
+STATE:
+- Identified root cause: coda_adapter.py SQL queries referenced `name` and `parent_id` columns that don't exist in SQLite schema.
+- Actual schema: pages table has `canvas_id`, `title` (not `name`), `content`, `file_path`, `char_count`, `extracted_at` (no `parent_id`).
+- Fixed _extract_page(), _extract_all_pages(), and _row_to_page_content() methods.
+
+CHANGES:
+- src/research/adapters/coda_adapter.py:
+  - Changed `name` -> `title` in SELECT queries
+  - Removed `parent_id` from SELECT queries
+  - Removed `parent_id` from metadata dict in _row_to_page_content()
+
+TEST RESULTS:
+- All 18 coda-related tests pass.
+- 3 pre-existing failures in unrelated tests (latency, theme extraction).
+- No new failures introduced.
+
+NEXT:
+- Commit the fix.
+- Create PR for #62.
+- Wait for 5-personality review and CONVERGED comment.

--- a/src/research/adapters/coda_adapter.py
+++ b/src/research/adapters/coda_adapter.py
@@ -105,7 +105,7 @@ class CodaSearchAdapter(SearchSourceAdapter):
     def _extract_page(self, cur: sqlite3.Cursor, page_id: str) -> Optional[SearchableContent]:
         """Extract a single page."""
         cur.execute("""
-            SELECT canvas_id, name, content, parent_id
+            SELECT canvas_id, title, content
             FROM pages
             WHERE canvas_id = ?
         """, (page_id,))
@@ -119,7 +119,7 @@ class CodaSearchAdapter(SearchSourceAdapter):
     def _extract_all_pages(self, cur: sqlite3.Cursor, limit: Optional[int]) -> Iterator[SearchableContent]:
         """Extract all pages."""
         query = """
-            SELECT canvas_id, name, content, parent_id
+            SELECT canvas_id, title, content
             FROM pages
             WHERE content IS NOT NULL AND LENGTH(content) > 50
             ORDER BY canvas_id
@@ -140,7 +140,7 @@ class CodaSearchAdapter(SearchSourceAdapter):
             return None
 
         page_id = row["canvas_id"]
-        title = row["name"] or f"Page {page_id}"
+        title = row["title"] or f"Page {page_id}"
 
         # Extract participant info from title if present
         participant = None
@@ -169,7 +169,6 @@ class CodaSearchAdapter(SearchSourceAdapter):
             metadata={
                 "page_type": page_type,
                 "participant": participant,
-                "parent_id": row["parent_id"],
             }
         )
 


### PR DESCRIPTION
## Summary
- Fixed SQL queries in `coda_adapter.py` that referenced non-existent columns
- Changed `name` → `title` to match actual SQLite schema
- Removed `parent_id` from queries and metadata (column doesn't exist)

## Root Cause
The adapter was written assuming the pages table had `name` and `parent_id` columns, but the actual schema has `title` and no `parent_id`:

```sql
CREATE TABLE pages (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  canvas_id TEXT UNIQUE NOT NULL,
  title TEXT NOT NULL,          -- was referenced as 'name'
  content TEXT NOT NULL,
  file_path TEXT,
  char_count INTEGER,
  extracted_at TEXT
);
```

## Test plan
- [x] All 18 coda-related tests pass
- [x] No new test failures introduced
- [ ] Manual verification: `python scripts/run_initial_embeddings.py --limit 5 -v` processes coda_page source

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)