### PR TITLE
feat(evidence): Implement suggested evidence accept/reject workflow

### DIFF
--- a/ralph/progress.txt
+++ b/ralph/progress.txt
@@ -392,9 +392,151 @@ TEST RESULTS:
 - No new failures introduced
 
 COMMITS:
-- (pending commit)
+- 53556a2: feat(pipeline): Add run summary with new stories panel
+- f865d68: fix(pipeline): Address Round 1 review issues
+
+PR CREATED:
+- PR URL: https://github.com/paulyokota/FeedForward/pull/70
+
+ROUND 1 REVIEW:
+- Reginald: BLOCK (R1 null guard, R2 dep cycle)
+- Sanjay: REQUEST CHANGES (S1 timestamp validation)
+- Quinn: REQUEST CHANGES (Q1-Q5 quality issues)
+- Dmitri: APPROVE (D1 minor dep issue)
+- Maya: REQUEST CHANGES (M1-M4 maintainability)
+
+ROUND 1 FIXES (commit f865d68):
+- R1: Added null guard for started_at
+- R2/D1: Removed selectedRunId from fetchData deps, added ref
+- S1: Added validate_iso_timestamp() with 5 tests
+- M2/M3/M4: Extracted constant, renamed function, added comments
+
+ROUND 2 REVIEW:
+- Reginald: APPROVE (R1, R2 verified fixed, 0 new issues)
+- Sanjay: APPROVE (S1 verified fixed, 0 new issues)
+- Quinn: APPROVE (Q4 verified fixed, 1 non-blocking Q6)
+- Dmitri: APPROVE (D1 verified fixed, 0 new issues)
+- Maya: APPROVE (M2-M4 verified fixed, 0 new issues)
+
+CONVERGED in 2 rounds. PR #70 merged (commit d032b57).
+
+STATUS: COMPLETE
+
+---
+
+ITERATION: 6
+ISSUE: #56 Story detail implementation context section
+STATE:
+- Implemented all Issue #56 requirements
+- Added Implementation Context section to story detail page
+
+CHANGES:
+
+Webapp (Next.js):
+- webapp/src/lib/types.ts:
+  - Added CodeContextClassification, CodeContextFile, CodeContextSnippet, CodeContext types
+  - Added code_context field to Story interface
+- webapp/src/components/ImplementationContext.tsx (NEW):
+  - Classification summary (category, confidence badge, reasoning, keywords)
+  - Relevant files list with line numbers and relevance descriptions
+  - Code snippets display
+  - Copy-to-clipboard for file paths with visual feedback
+  - Pending state for stories not yet processed
+- webapp/src/app/story/[id]/page.tsx:
+  - Added ImplementationContext import
+  - Integrated component between Evidence and Comments sections
+- webapp/src/components/__tests__/ImplementationContext.test.tsx (NEW):
+  - 14 tests for pending state, file display, copy functionality
+- webapp/src/components/__tests__/DroppableColumn.test.tsx:
+  - Added code_context: null to mock story factory
+
+TEST RESULTS:
+- 14 new UI tests pass (ImplementationContext)
+- 109 total webapp tests pass
+- 643 backend tests pass (3 pre-existing failures unchanged)
+- ESLint passes on new files
+
+COMMITS:
+- 486301f: feat(stories): Add Implementation Context section to story detail page
+
+PR CREATED:
+- PR URL: https://github.com/paulyokota/FeedForward/pull/71
+
+5-PERSONALITY REVIEW - ROUND 1:
+Verdicts:
+- Reginald: APPROVE (code logic correct, edge cases handled)
+- Sanjay: APPROVE (no XSS, proper escaping, safe clipboard API)
+- Quinn: APPROVE (clear pending state, good copy UX, 14 tests)
+- Dmitri: APPROVE (simple prop interface, no over-abstraction)
+- Maya: APPROVE (well-structured, consistent patterns)
+
+Result: 0 blocking issues - CONVERGED in Round 1.
+
+PR #71 merged successfully (commit 079bacd).
+
+STATUS: COMPLETE
+
+---
+
+ITERATION: 7
+ISSUE: #55 Suggested evidence accept/reject workflow
+STATE:
+- Implemented all Issue #55 requirements
+- Final task in Hybrid Week 4 roadmap
+
+CHANGES:
+
+Backend (Python):
+- src/api/routers/research.py:
+  - Updated GET /api/research/stories/{story_id}/suggested-evidence:
+    - Now returns status field ("suggested" or "accepted") for each item
+    - Fetches all decisions (not just rejected) to set correct status
+    - Rejected items still filtered out
+  - Updated _record_evidence_decision() to use UPSERT:
+    - Supports state transitions: accepted→rejected, rejected→accepted
+    - Uses ON CONFLICT DO UPDATE for idempotent operations
+    - No longer returns 409 on duplicate - updates decision instead
+- tests/test_research.py:
+  - Replaced duplicate decision test with 3 new state transition tests:
+    - test_state_transition_accepted_to_rejected
+    - test_state_transition_rejected_to_accepted
+    - test_repeat_same_decision_succeeds
+  - Updated filtering tests to use new query structure (evidence_id, decision)
+  - Added test_suggested_evidence_shows_accepted_status
+
+Webapp (Next.js):
+- webapp/src/lib/api.ts:
+  - Fixed API routes to use /api/research/stories instead of /api/stories
+  - Added encodeURIComponent for evidence_id in URL paths
+  - getSuggestedEvidence now extracts .suggestions from response wrapper
+- webapp/src/components/SuggestedEvidence.tsx:
+  - Removed client-side filter for "suggested" only - now shows both suggested and accepted
+  - Accept handler now updates item status to "accepted" locally (not removes)
+  - Added "Accepted" badge for accepted items
+  - Shows Accept/Reject buttons for suggested items, Undo button for accepted
+  - Added CSS for accepted badge, accepted card styling, undo button
+- webapp/src/components/__tests__/SuggestedEvidence.test.tsx (NEW):
+  - 21 tests covering:
+    - Loading and empty states
+    - Suggestions display (cards, similarity, source badges)
+    - Status display (accepted badge visibility)
+    - Action buttons (Accept/Reject for suggested, Undo for accepted)
+    - Accept/Reject/Undo API calls and UI updates
+    - Processing state (disabled buttons)
+    - Error handling
+
+TEST RESULTS:
+- 51 backend research tests pass
+- 21 new UI tests pass (SuggestedEvidence)
+- 130 total webapp tests pass
+- ESLint clean on new/modified files
+- No new failures introduced (3 pre-existing failures unchanged)
+
+COMMITS:
+- [pending]: feat(evidence): Implement suggested evidence accept/reject workflow
 
 NEXT:
-- Create PR for Issue #54
-- Wait for 5-personality review to CONVERGE
-- Merge and proceed to Issue #56
+- Create PR for Issue #55
+- Run 5-personality review
+- Wait for CONVERGED
+- Merge PR

--- a/webapp/src/components/__tests__/SuggestedEvidence.test.tsx
+++ b/webapp/src/components/__tests__/SuggestedEvidence.test.tsx
@@ -1,0 +1,433 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SuggestedEvidence } from "../SuggestedEvidence";
+import { api } from "@/lib/api";
+
+// Mock the API module
+jest.mock("@/lib/api", () => ({
+  api: {
+    research: {
+      getSuggestedEvidence: jest.fn(),
+      acceptEvidence: jest.fn(),
+      rejectEvidence: jest.fn(),
+    },
+  },
+}));
+
+const mockApi = api as jest.Mocked<typeof api>;
+
+describe("SuggestedEvidence", () => {
+  const storyId = "test-story-123";
+
+  const mockSuggestions = [
+    {
+      id: "coda_page:page_1",
+      source_type: "coda_page" as const,
+      source_id: "page_1",
+      title: "Research Page 1",
+      snippet: "This is relevant research content...",
+      similarity: 0.85,
+      url: "https://coda.io/page_1",
+      metadata: {},
+      status: "suggested" as const,
+    },
+    {
+      id: "coda_theme:theme_1",
+      source_type: "coda_theme" as const,
+      source_id: "theme_1",
+      title: "Theme Research",
+      snippet: "Theme-related content...",
+      similarity: 0.75,
+      url: "https://coda.io/theme_1",
+      metadata: {},
+      status: "accepted" as const,
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Loading State", () => {
+    it("shows loading indicator while fetching", () => {
+      mockApi.research.getSuggestedEvidence.mockImplementation(
+        () => new Promise(() => {}), // Never resolves
+      );
+
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      expect(
+        screen.getByText("Finding related research..."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Empty State", () => {
+    it("renders nothing when no suggestions", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([]);
+
+      const { container } = render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(container.firstChild).toBeNull();
+      });
+    });
+  });
+
+  describe("Suggestions Display", () => {
+    it("renders suggested evidence cards", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue(mockSuggestions);
+
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Research Page 1")).toBeInTheDocument();
+        expect(screen.getByText("Theme Research")).toBeInTheDocument();
+      });
+    });
+
+    it("displays similarity scores as percentages", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue(mockSuggestions);
+
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("85% match")).toBeInTheDocument();
+        expect(screen.getByText("75% match")).toBeInTheDocument();
+      });
+    });
+
+    it("shows source type badges", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue(mockSuggestions);
+
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Coda Research")).toBeInTheDocument();
+        expect(screen.getByText("Coda Theme")).toBeInTheDocument();
+      });
+    });
+
+    it("displays suggestion count", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue(mockSuggestions);
+
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("2")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Status Display", () => {
+    it("shows Accepted badge for accepted items", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        { ...mockSuggestions[1], status: "accepted" as const },
+      ]);
+
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Accepted")).toBeInTheDocument();
+      });
+    });
+
+    it("does not show Accepted badge for suggested items", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        { ...mockSuggestions[0], status: "suggested" as const },
+      ]);
+
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Research Page 1")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("Accepted")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Action Buttons", () => {
+    it("shows Accept and Reject buttons for suggested items", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        mockSuggestions[0],
+      ]);
+
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /accept/i }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: /reject/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows Undo button for accepted items instead of Accept/Reject", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        mockSuggestions[1],
+      ]);
+
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /undo/i }),
+        ).toBeInTheDocument();
+      });
+
+      // Accept button should not exist (not "Accept this evidence" aria-label)
+      expect(
+        screen.queryByRole("button", { name: /^accept this evidence$/i }),
+      ).not.toBeInTheDocument();
+      // Reject button should not exist
+      expect(
+        screen.queryByRole("button", { name: /^reject this evidence$/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows View link for all items", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue(mockSuggestions);
+
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        const viewLinks = screen.getAllByRole("link", { name: /view/i });
+        expect(viewLinks).toHaveLength(2);
+        expect(viewLinks[0]).toHaveAttribute("href", "https://coda.io/page_1");
+        expect(viewLinks[1]).toHaveAttribute("href", "https://coda.io/theme_1");
+      });
+    });
+  });
+
+  describe("Accept Action", () => {
+    it("calls accept API when clicking Accept button", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        mockSuggestions[0],
+      ]);
+      mockApi.research.acceptEvidence.mockResolvedValue({ success: true });
+
+      const user = userEvent.setup();
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /accept/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /accept/i }));
+
+      expect(mockApi.research.acceptEvidence).toHaveBeenCalledWith(
+        storyId,
+        "coda_page:page_1",
+      );
+    });
+
+    it("updates item to accepted status after successful accept", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        mockSuggestions[0],
+      ]);
+      mockApi.research.acceptEvidence.mockResolvedValue({ success: true });
+
+      const user = userEvent.setup();
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /accept/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /accept/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Accepted")).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: /undo/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("calls onEvidenceAccepted callback when provided", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        mockSuggestions[0],
+      ]);
+      mockApi.research.acceptEvidence.mockResolvedValue({ success: true });
+
+      const onAccepted = jest.fn();
+      const user = userEvent.setup();
+      render(
+        <SuggestedEvidence storyId={storyId} onEvidenceAccepted={onAccepted} />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /accept/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /accept/i }));
+
+      await waitFor(() => {
+        expect(onAccepted).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("Reject Action", () => {
+    it("calls reject API when clicking Reject button", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        mockSuggestions[0],
+      ]);
+      mockApi.research.rejectEvidence.mockResolvedValue({ success: true });
+
+      const user = userEvent.setup();
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /reject/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /reject/i }));
+
+      expect(mockApi.research.rejectEvidence).toHaveBeenCalledWith(
+        storyId,
+        "coda_page:page_1",
+      );
+    });
+
+    it("removes item from UI after successful reject", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        mockSuggestions[0],
+      ]);
+      mockApi.research.rejectEvidence.mockResolvedValue({ success: true });
+
+      const user = userEvent.setup();
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Research Page 1")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /reject/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText("Research Page 1")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Undo Action (State Transition)", () => {
+    it("calls reject API when clicking Undo button on accepted item", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        mockSuggestions[1],
+      ]);
+      mockApi.research.rejectEvidence.mockResolvedValue({ success: true });
+
+      const user = userEvent.setup();
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /undo/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /undo/i }));
+
+      expect(mockApi.research.rejectEvidence).toHaveBeenCalledWith(
+        storyId,
+        "coda_theme:theme_1",
+      );
+    });
+
+    it("removes accepted item from UI after undo", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        mockSuggestions[1],
+      ]);
+      mockApi.research.rejectEvidence.mockResolvedValue({ success: true });
+
+      const user = userEvent.setup();
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Theme Research")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /undo/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText("Theme Research")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Processing State", () => {
+    it("disables buttons during processing", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        mockSuggestions[0],
+      ]);
+      mockApi.research.acceptEvidence.mockImplementation(
+        () => new Promise(() => {}), // Never resolves
+      );
+
+      const user = userEvent.setup();
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /accept/i })).toBeEnabled();
+      });
+
+      await user.click(screen.getByRole("button", { name: /accept/i }));
+
+      expect(screen.getByRole("button", { name: /accept/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /reject/i })).toBeDisabled();
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("handles API fetch error gracefully", async () => {
+      mockApi.research.getSuggestedEvidence.mockRejectedValue(
+        new Error("API Error"),
+      );
+
+      const { container } = render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        // Should render nothing on error (silent failure)
+        expect(container.firstChild).toBeNull();
+      });
+    });
+
+    it("handles accept error gracefully without crashing", async () => {
+      mockApi.research.getSuggestedEvidence.mockResolvedValue([
+        mockSuggestions[0],
+      ]);
+      mockApi.research.acceptEvidence.mockRejectedValue(
+        new Error("Accept failed"),
+      );
+
+      const user = userEvent.setup();
+      render(<SuggestedEvidence storyId={storyId} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /accept/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /accept/i }));
+
+      // Should still show the item (not updated)
+      await waitFor(() => {
+        expect(screen.getByText("Research Page 1")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /accept/i })).toBeEnabled();
+      });
+    });
+  });
+});

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -258,7 +258,10 @@ export const api = {
     getSuggestedEvidence: async (
       storyId: string,
     ): Promise<SuggestedEvidence[]> => {
-      return fetcher(`/api/stories/${storyId}/suggested-evidence`);
+      const response = await fetcher<{ suggestions: SuggestedEvidence[] }>(
+        `/api/research/stories/${storyId}/suggested-evidence`,
+      );
+      return response.suggestions;
     },
 
     acceptEvidence: async (
@@ -266,7 +269,7 @@ export const api = {
       evidenceId: string,
     ): Promise<{ success: boolean }> => {
       return fetcher(
-        `/api/stories/${storyId}/suggested-evidence/${evidenceId}/accept`,
+        `/api/research/stories/${storyId}/suggested-evidence/${encodeURIComponent(evidenceId)}/accept`,
         {
           method: "POST",
         },
@@ -278,7 +281,7 @@ export const api = {
       evidenceId: string,
     ): Promise<{ success: boolean }> => {
       return fetcher(
-        `/api/stories/${storyId}/suggested-evidence/${evidenceId}/reject`,
+        `/api/research/stories/${storyId}/suggested-evidence/${encodeURIComponent(evidenceId)}/reject`,
         {
           method: "POST",
         },


### PR DESCRIPTION
## Summary
- Implements full accept/reject workflow for suggested evidence on stories
- Fixes webapp API routes to use correct backend endpoints (`/api/research/stories/...`)
- Adds state transition support (accepted↔rejected) with audit trail
- Shows accepted items with status badges and Undo functionality

## Test plan
- [ ] Backend tests pass (`pytest tests/test_research.py -v`) - 51 tests ✓
- [ ] Webapp tests pass (`npm test`) - 130 tests including 21 new SuggestedEvidence tests ✓
- [ ] Accept suggested evidence → shows "Accepted" badge and Undo button
- [ ] Reject suggested evidence → removes from list
- [ ] Undo accepted evidence → transitions to rejected, removes from list
- [ ] Reload page → accepted items retain status

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)