### PR TITLE
feat(pipeline): Integrate ResolutionAnalyzer and KnowledgeExtractor

### DIFF
--- a/.claude/decisions/milestone-5-pr3-architecture.md
+++ b/.claude/decisions/milestone-5-pr3-architecture.md
@@ -1,0 +1,216 @@
+# Architecture Decision: ThemeTracker, ClassificationManager, and ResolutionAnalyzer
+
+**Date**: 2025-01-21
+**Author**: Priya (Architecture)
+**Issues**: #78, #79
+**Status**: DECISION MADE
+
+---
+
+## Context
+
+During Milestone 5, we identified several modules that exist but are not used by the current UI pipeline (`src/api/routers/pipeline.py`):
+
+| Module                  | Location                        | Used By                      | Not Used By          |
+| ----------------------- | ------------------------------- | ---------------------------- | -------------------- |
+| `ThemeTracker`          | `src/theme_tracker.py`          | CLI (`src/cli.py`), scripts  | UI pipeline          |
+| `ClassificationManager` | `src/classification_manager.py` | Demo/test tools only         | UI pipeline, CLI     |
+| `ResolutionAnalyzer`    | `src/resolution_analyzer.py`    | `ClassificationManager` only | UI pipeline directly |
+| `KnowledgeExtractor`    | `src/knowledge_extractor.py`    | `ClassificationManager` only | UI pipeline directly |
+
+The recent PR #86 deleted the legacy `src/pipeline.py` and `src/classifier.py` because the current pipeline uses `src/two_stage_pipeline.py`. This raises the question: should these other modules also be retired or integrated?
+
+---
+
+## Analysis
+
+### ThemeTracker (`src/theme_tracker.py`)
+
+**What it provides:**
+
+1. Theme aggregation across conversations (occurrence counts, first/last seen)
+2. Excerpt scoring for ticket quality (specificity patterns, repro steps, media links)
+3. Shortcut ticket templates (bug vs. trend formats)
+4. Ticket lifecycle management (create, update, close stale, reopen)
+5. Source tracking (Intercom vs Coda counts)
+
+**Current usage:**
+
+- CLI: `themes`, `trending`, `ticket`, `pending`, `extract` commands
+- Scripts: `backfill_historical.py`, `process_historical.py`, `reextract_catchall.py`
+- Tests: `test_communities_bug_store.py`
+
+**NOT used by:**
+
+- UI pipeline (`src/api/routers/pipeline.py`)
+- Story creation flow (uses `StoryService`, not `ThemeTracker`)
+
+**Key insight:** The UI pipeline has its own story creation path via `StoryCreationService` which:
+
+- Groups themes by signature
+- Creates stories via `StoryService`
+- Handles orphans via `OrphanService`
+- Manages evidence via `EvidenceService`
+
+ThemeTracker's ticket creation is a **parallel, alternative path** to Shortcut tickets that bypasses the story workflow entirely.
+
+### ClassificationManager (`src/classification_manager.py`)
+
+**What it provides:**
+
+- Orchestration wrapper around Stage 1 + Stage 2 classifiers
+- Integration with `ResolutionAnalyzer` and `KnowledgeExtractor`
+- Convenience methods: `classify_new_conversation`, `refine_with_support_context`, `classify_complete_conversation`
+
+**Current usage:**
+
+- Demo tools only: `tools/demo_integrated_system.py`
+- Test tools only: `tools/test_phase1_*.py`
+
+**NOT used by:**
+
+- UI pipeline (uses `two_stage_pipeline.py` directly)
+- CLI (uses classifier functions directly)
+
+**Key insight:** The UI pipeline (`two_stage_pipeline.py`) already does what `ClassificationManager` does:
+
+- Calls `classify_stage1_async` and `classify_stage2_async`
+- Uses `detect_resolution_signal` (a simpler version of `ResolutionAnalyzer`)
+- Stores results via `store_classification_results_batch`
+
+`ClassificationManager` is essentially a **synchronous orchestration wrapper** that was created for testing/demo purposes but never integrated into the main pipeline.
+
+### ResolutionAnalyzer (`src/resolution_analyzer.py`)
+
+**What it provides:**
+
+- Pattern-based detection of support actions (refund, ticket created, docs link, etc.)
+- Maps actions to conversation types
+- Confidence boost calculation when resolution agrees with prediction
+
+**Current usage:**
+
+- Only via `ClassificationManager`
+
+**Key insight:** `two_stage_pipeline.py` has its own `detect_resolution_signal()` function that does a simpler version of this. The UI pipeline doesn't use the full `ResolutionAnalyzer` at all.
+
+### KnowledgeExtractor (`src/knowledge_extractor.py`)
+
+**What it provides:**
+
+- Extracts root cause, solution, product mentions from support responses
+- Detects self-service gaps (manual support work that could be automated)
+- Terminology extraction for vocabulary learning
+
+**Current usage:**
+
+- Only via `ClassificationManager`
+
+**Key insight:** This is designed for "continuous learning" feedback loops. The current pipeline doesn't implement this feedback system - knowledge is extracted but never stored or acted upon.
+
+---
+
+## Decision
+
+### Option B: RETIRE ClassificationManager, ResolutionAnalyzer, KnowledgeExtractor
+
+**Rationale:**
+
+1. **ClassificationManager is redundant**: `two_stage_pipeline.py` provides the same functionality with async support and tighter integration with the storage layer. The manager adds an unnecessary abstraction layer.
+
+2. **ResolutionAnalyzer adds marginal value**: The simple `detect_resolution_signal()` in `two_stage_pipeline.py` covers the main use case. The full pattern-based analyzer was designed for a feature (confidence boost) that isn't used.
+
+3. **KnowledgeExtractor is orphaned infrastructure**: It extracts knowledge but there's no system that stores or uses this knowledge. It's premature optimization for a feedback loop that doesn't exist.
+
+4. **Demo/test tools can be updated or removed**: The `tools/` scripts that use these modules are not part of production.
+
+**Files to delete:**
+
+- `src/classification_manager.py`
+- `src/resolution_analyzer.py`
+- `src/knowledge_extractor.py`
+- `config/resolution_patterns.json` (used by ResolutionAnalyzer)
+- `tools/demo_integrated_system.py`
+- `tools/test_phase1_*.py` (5 files)
+- `tools/test_integrated_system.py`
+
+### Option C: KEEP ThemeTracker for CLI-only use
+
+**Rationale:**
+
+1. **CLI is a legitimate use case**: The CLI provides operational visibility for debugging and monitoring that the UI doesn't cover:
+   - `python src/cli.py trending` - quick trending report
+   - `python src/cli.py ticket <sig>` - preview ticket content
+   - `python src/cli.py pending` - what's ready for tickets
+
+2. **Distinct from UI story creation**: ThemeTracker creates Shortcut tickets directly, while the UI creates Stories that later sync to external systems. These are **different workflows for different use cases**.
+
+3. **Scripts depend on it**: Historical data processing scripts use ThemeTracker for backfill operations.
+
+4. **Low maintenance cost**: ThemeTracker is stable, well-tested, and doesn't conflict with the UI pipeline.
+
+**Recommendation**: Keep ThemeTracker but **document clearly** that it's CLI-only and not part of the UI pipeline flow.
+
+---
+
+## Summary
+
+| Module                  | Decision   | Rationale                                       |
+| ----------------------- | ---------- | ----------------------------------------------- |
+| `ClassificationManager` | **DELETE** | Redundant with `two_stage_pipeline.py`          |
+| `ResolutionAnalyzer`    | **DELETE** | Marginal value, simpler version in pipeline     |
+| `KnowledgeExtractor`    | **DELETE** | Orphaned infrastructure, no downstream consumer |
+| `ThemeTracker`          | **KEEP**   | Legitimate CLI use case, distinct from UI flow  |
+
+---
+
+## Implementation Plan
+
+### PR 3A: Delete ClassificationManager ecosystem
+
+- [ ] Delete `src/classification_manager.py`
+- [ ] Delete `src/resolution_analyzer.py`
+- [ ] Delete `src/knowledge_extractor.py`
+- [ ] Delete `config/resolution_patterns.json`
+- [ ] Delete `tools/demo_integrated_system.py`
+- [ ] Delete `tools/test_phase1_live.py`
+- [ ] Delete `tools/test_phase1_quick.py`
+- [ ] Delete `tools/test_phase1_system.py`
+- [ ] Delete `tools/test_phase1_realdata.py`
+- [ ] Delete `tools/test_integrated_system.py`
+- [ ] Update CLAUDE.md if any references exist
+
+### PR 3B: Document ThemeTracker CLI-only scope
+
+- [ ] Add docstring clarifying ThemeTracker is CLI-only, not used by UI
+- [ ] Update any docs that might suggest ThemeTracker is part of main pipeline
+
+---
+
+## Alternatives Considered
+
+### Alternative A: Integrate into UI pipeline
+
+**Rejected because:**
+
+- ResolutionAnalyzer provides marginal accuracy improvement over simple detection
+- KnowledgeExtractor would require building a feedback system that doesn't exist
+- ClassificationManager is literally redundant with existing async pipeline
+
+### Alternative B: Full delete including ThemeTracker
+
+**Rejected because:**
+
+- CLI provides operational value for debugging
+- Historical scripts would break
+- Different use case (direct Shortcut tickets) from UI (Stories)
+
+---
+
+## References
+
+- Issue #78: ThemeTracker aggregation helpers
+- Issue #79: ClassificationManager + ResolutionAnalyzer
+- PR #86: Deleted legacy pipeline.py and classifier.py
+- `src/two_stage_pipeline.py` - Current pipeline implementation
+- `src/api/routers/pipeline.py` - UI pipeline endpoints

--- a/.claude/decisions/milestone-5-pr3-integration.md
+++ b/.claude/decisions/milestone-5-pr3-integration.md
@@ -1,0 +1,557 @@
+# Architecture Decision: Integration of ResolutionAnalyzer and KnowledgeExtractor
+
+**Date**: 2025-01-21
+**Author**: Priya (Architecture)
+**Status**: DESIGN COMPLETE
+**Context**: User chose INTEGRATE over DELETE from milestone-5-pr3-architecture.md
+
+---
+
+## Overview
+
+This document designs how to wire `ResolutionAnalyzer` and `KnowledgeExtractor` into `two_stage_pipeline.py` while preserving async performance and enabling incremental rollout.
+
+---
+
+## Current State Analysis
+
+### Existing Pipeline Flow
+
+```
+two_stage_pipeline.py
+    |
+    +--> extract_support_messages()     # Extract support messages from raw conv
+    |
+    +--> detect_resolution_signal()     # Simple 6-phrase detection (lines 71-97)
+    |         |
+    |         +--> Returns: {"action": "resolved", "signal": phrase} or None
+    |
+    +--> classify_stage1_async()        # Fast routing classification
+    |
+    +--> classify_stage2_async()        # Refined analysis (uses resolution_action)
+    |
+    +--> store_classification_results_batch()  # Batch DB insert
+```
+
+### ResolutionAnalyzer Capabilities
+
+Located at: `/Users/paulyokota/Documents/GitHub/FeedForward/src/resolution_analyzer.py`
+
+```python
+# Input: List of support messages
+# Output:
+{
+    "primary_action": {
+        "action": "refund_processed",        # Specific action detected
+        "category": "billing",               # Category (billing, account, etc.)
+        "conversation_type": "billing_question",  # Suggested type
+        "action_category": "billing_resolution",   # Action type
+        "matched_keyword": "processed your refund"  # What triggered match
+    },
+    "all_actions": [...],                    # All detected actions
+    "action_count": int,                     # Number of actions
+    "categories": ["billing", "account"],    # Unique categories
+    "suggested_type": "billing_question"     # From primary action
+}
+```
+
+**Pattern Coverage**: 20+ patterns across 6 categories:
+
+- billing (refund, payment update, subscription cancel, plan change)
+- account (password reset, session cleared, account unlocked, oauth reconnect)
+- product_issue (ticket created, bug confirmed, escalated)
+- how_to (docs link, tutorial, walkthrough)
+- feature_request (not available, roadmap, enhancement logged)
+- configuration (settings adjusted, integration configured, setup completed)
+
+### KnowledgeExtractor Capabilities
+
+Located at: `/Users/paulyokota/Documents/GitHub/FeedForward/src/knowledge_extractor.py`
+
+```python
+# Input: customer_message, support_messages, conversation_type
+# Output:
+{
+    "conversation_type": str,
+    "root_cause": str | None,              # "this is due to a downtime"
+    "solution_provided": str | None,        # "I've processed your refund"
+    "product_mentions": ["Tailwind", "Pro plan"],
+    "feature_mentions": ["drafts", "queue"],
+    "customer_terminology": [...],          # Phrases customer used
+    "support_terminology": [...],           # Phrases support used
+    "self_service_gap": bool,               # Could this be automated?
+    "gap_evidence": str | None              # "Support manually cancelled"
+}
+```
+
+### Database Schema (Current)
+
+From migration `001_add_two_stage_classification.sql`:
+
+```sql
+-- Already exists:
+resolution_action VARCHAR(100),     -- Used: stores simple action
+resolution_detected BOOLEAN,        -- Used: TRUE if detected
+support_insights JSONB              -- Unused: designed for this purpose
+```
+
+---
+
+## Design Decisions
+
+### 1. Where to Call These Modules?
+
+**Decision**: Call in Stage 2 processing, immediately after support messages are available.
+
+**Rationale**:
+
+- Stage 1 has no support context - these modules need support messages
+- Call BEFORE Stage 2 LLM so resolution analysis can inform Stage 2
+- Run in parallel with Stage 2 where possible (resolution analysis is fast)
+
+**Integration Point** (in `classify_conversation_async`):
+
+```
+if support_messages:
+    # NEW: Rich resolution analysis (fast, pattern-based)
+    resolution_analysis = resolution_analyzer.analyze_conversation(support_messages)
+
+    # EXISTING: Stage 2 LLM classification (slow, needs semaphore)
+    stage2_result = await classify_stage2_async(
+        resolution_signal=resolution_analysis["suggested_type"],  # Enhanced signal
+        ...
+    )
+
+    # NEW: Knowledge extraction (fast, pattern-based)
+    knowledge = knowledge_extractor.extract_from_conversation(
+        customer_message,
+        support_messages,
+        stage2_result["conversation_type"]
+    )
+```
+
+### 2. How to Store the Outputs?
+
+**Decision**: Use existing `support_insights JSONB` column for both modules.
+
+**Schema Design**:
+
+```json
+{
+  "resolution_analysis": {
+    "primary_action": "refund_processed",
+    "action_category": "billing_resolution",
+    "all_actions": ["refund_processed", "plan_changed"],
+    "categories": ["billing"],
+    "suggested_type": "billing_question",
+    "matched_keywords": ["processed your refund"]
+  },
+  "knowledge": {
+    "root_cause": "This is due to a known billing sync issue",
+    "solution_provided": "I've processed your refund",
+    "product_mentions": ["Pro plan"],
+    "feature_mentions": ["billing", "subscription"],
+    "self_service_gap": true,
+    "gap_evidence": "Support manually cancelled"
+  }
+}
+```
+
+**Why JSONB in existing column**:
+
+- No schema migration required
+- `support_insights` was designed for exactly this purpose (see migration comment)
+- Flexible structure allows iterative refinement
+- Queryable via PostgreSQL JSON operators when needed
+
+### 3. Replace or Augment `detect_resolution_signal()`?
+
+**Decision**: REPLACE with `ResolutionAnalyzer`, but add backward-compatible wrapper.
+
+**Rationale**:
+
+- `detect_resolution_signal()` is a subset of `ResolutionAnalyzer`
+- Same 6 phrases plus 14 more patterns
+- Same output format can be maintained for Stage 2 LLM
+- Rich data stored separately in `support_insights`
+
+**Backward Compatibility**:
+
+```python
+def detect_resolution_signal(support_messages: List[str]) -> Optional[Dict[str, Any]]:
+    """
+    Detect resolution patterns. Uses ResolutionAnalyzer internally.
+
+    Returns simple format for backward compatibility with Stage 2 prompt.
+    Rich analysis stored in support_insights during pipeline run.
+    """
+    analyzer = ResolutionAnalyzer()
+    analysis = analyzer.analyze_conversation(support_messages)
+
+    if analysis["primary_action"]:
+        # Return simple format for Stage 2 LLM
+        return {
+            "action": analysis["primary_action"]["action"],
+            "signal": analysis["primary_action"]["matched_keyword"]
+        }
+    return None
+```
+
+### 4. Minimal vs Full Integration
+
+**Phase 1 (Minimal - This PR)**:
+
+- Replace `detect_resolution_signal()` with `ResolutionAnalyzer` wrapper
+- Store full analysis in `support_insights`
+- Add `KnowledgeExtractor` after Stage 2
+- Store knowledge in `support_insights`
+- No LLM changes, no new migrations
+
+**Phase 2 (Future - Separate PR)**:
+
+- Enhance Stage 2 prompt with resolution categories
+- Confidence boost from resolution agreement
+- Self-service gap reporting/alerting
+- Terminology feedback to vocabulary
+
+---
+
+## Implementation Plan
+
+### File Changes
+
+| File                               | Change                                                         | Owner  |
+| ---------------------------------- | -------------------------------------------------------------- | ------ |
+| `src/two_stage_pipeline.py`        | Replace `detect_resolution_signal()`, add knowledge extraction | Marcus |
+| `src/resolution_analyzer.py`       | No changes (already complete)                                  | -      |
+| `src/knowledge_extractor.py`       | No changes (already complete)                                  | -      |
+| `src/db/classification_storage.py` | Update to store `support_insights`                             | Marcus |
+
+### Code Changes
+
+#### 1. Update `two_stage_pipeline.py`
+
+```python
+# At top of file
+from resolution_analyzer import ResolutionAnalyzer
+from knowledge_extractor import KnowledgeExtractor
+
+# Module-level instances (initialized once)
+_resolution_analyzer = None
+_knowledge_extractor = None
+
+def get_resolution_analyzer() -> ResolutionAnalyzer:
+    global _resolution_analyzer
+    if _resolution_analyzer is None:
+        _resolution_analyzer = ResolutionAnalyzer()
+    return _resolution_analyzer
+
+def get_knowledge_extractor() -> KnowledgeExtractor:
+    global _knowledge_extractor
+    if _knowledge_extractor is None:
+        _knowledge_extractor = KnowledgeExtractor()
+    return _knowledge_extractor
+
+
+def detect_resolution_signal(support_messages: List[str]) -> Optional[Dict[str, Any]]:
+    """
+    Detect resolution patterns using ResolutionAnalyzer.
+
+    Returns simple format for backward compatibility with Stage 2 prompt.
+    Full analysis available via get_full_resolution_analysis().
+    """
+    if not support_messages:
+        return None
+
+    analyzer = get_resolution_analyzer()
+    analysis = analyzer.analyze_conversation(support_messages)
+
+    if analysis["primary_action"]:
+        return {
+            "action": analysis["primary_action"]["action"],
+            "signal": analysis["primary_action"]["matched_keyword"]
+        }
+    return None
+
+
+def get_full_resolution_analysis(support_messages: List[str]) -> Dict[str, Any]:
+    """Get full resolution analysis for storage in support_insights."""
+    if not support_messages:
+        return {}
+
+    analyzer = get_resolution_analyzer()
+    analysis = analyzer.analyze_conversation(support_messages)
+
+    return {
+        "primary_action": analysis["primary_action"]["action"] if analysis["primary_action"] else None,
+        "action_category": analysis["primary_action"]["action_category"] if analysis["primary_action"] else None,
+        "all_actions": [a["action"] for a in analysis["all_actions"]],
+        "categories": analysis["categories"],
+        "suggested_type": analysis["suggested_type"],
+        "matched_keywords": [a["matched_keyword"] for a in analysis["all_actions"]]
+    }
+
+
+def extract_knowledge(
+    customer_message: str,
+    support_messages: List[str],
+    conversation_type: str
+) -> Dict[str, Any]:
+    """Extract knowledge for storage in support_insights."""
+    if not support_messages:
+        return {}
+
+    extractor = get_knowledge_extractor()
+    knowledge = extractor.extract_from_conversation(
+        customer_message,
+        support_messages,
+        conversation_type
+    )
+
+    # Return subset of fields for storage (exclude verbose terminology)
+    return {
+        "root_cause": knowledge["root_cause"],
+        "solution_provided": knowledge["solution_provided"],
+        "product_mentions": knowledge["product_mentions"],
+        "feature_mentions": knowledge["feature_mentions"],
+        "self_service_gap": knowledge["self_service_gap"],
+        "gap_evidence": knowledge["gap_evidence"]
+    }
+```
+
+#### 2. Update `classify_conversation_async()`
+
+```python
+async def classify_conversation_async(
+    parsed: IntercomConversation,
+    raw_conversation: dict,
+    semaphore: asyncio.Semaphore,
+) -> Dict[str, Any]:
+    """
+    Run two-stage classification with resolution analysis and knowledge extraction.
+    """
+    support_messages = extract_support_messages(raw_conversation)
+
+    # Stage 1
+    stage1_result = await classify_stage1_async(
+        customer_message=parsed.source_body,
+        source_type=parsed.source_type,
+        source_url=parsed.source_url,
+        semaphore=semaphore,
+    )
+
+    # Stage 2 + Resolution + Knowledge (only if support responded)
+    stage2_result = None
+    resolution_signal = None
+    support_insights = None  # NEW
+
+    if support_messages:
+        # Resolution analysis (fast, no semaphore needed)
+        resolution_signal = detect_resolution_signal(support_messages)
+        resolution_action = resolution_signal.get("action") if resolution_signal else None
+
+        # Stage 2 LLM (slow, needs semaphore)
+        stage2_result = await classify_stage2_async(
+            customer_message=parsed.source_body,
+            support_messages=support_messages,
+            stage1_type=stage1_result["conversation_type"],
+            resolution_signal=resolution_action,
+            source_url=parsed.source_url,
+            semaphore=semaphore,
+        )
+
+        # Build support_insights (NEW)
+        final_type = stage2_result.get("conversation_type", stage1_result["conversation_type"])
+        support_insights = {
+            "resolution_analysis": get_full_resolution_analysis(support_messages),
+            "knowledge": extract_knowledge(
+                parsed.source_body,
+                support_messages,
+                final_type
+            )
+        }
+
+    return {
+        "conversation_id": parsed.id,
+        "created_at": parsed.created_at,
+        "source_body": parsed.source_body,
+        "source_type": parsed.source_type,
+        "source_url": parsed.source_url,
+        "contact_email": parsed.contact_email,
+        "contact_id": parsed.contact_id,
+        "stage1_result": stage1_result,
+        "stage2_result": stage2_result,
+        "support_messages": support_messages,
+        "resolution_signal": resolution_signal,
+        "support_insights": support_insights,  # NEW
+    }
+```
+
+#### 3. Update `store_classification_results_batch()`
+
+In `src/db/classification_storage.py`, ensure `support_insights` is included in the batch insert:
+
+```python
+# In the INSERT statement, add support_insights column
+# In the values tuple, add:
+Json(result.get("support_insights")) if result.get("support_insights") else None
+```
+
+---
+
+## Performance Considerations
+
+### Async Performance Preserved
+
+| Operation            | Current              | After Integration | Impact     |
+| -------------------- | -------------------- | ----------------- | ---------- |
+| Stage 1 LLM          | async with semaphore | unchanged         | none       |
+| Stage 2 LLM          | async with semaphore | unchanged         | none       |
+| Resolution analysis  | N/A                  | sync, ~1ms        | negligible |
+| Knowledge extraction | N/A                  | sync, ~1ms        | negligible |
+| DB batch insert      | unchanged            | +1 JSON column    | negligible |
+
+**Total impact**: <1ms per conversation, well within noise margin.
+
+### Memory Considerations
+
+- `ResolutionAnalyzer` loads `resolution_patterns.json` once (~5KB)
+- `KnowledgeExtractor` has no external data
+- Both are stateless pattern matchers - safe for concurrent use
+
+---
+
+## Incremental Rollout
+
+### Feature Flag Approach (Optional)
+
+```python
+ENABLE_RICH_RESOLUTION = os.getenv("ENABLE_RICH_RESOLUTION", "true").lower() == "true"
+ENABLE_KNOWLEDGE_EXTRACTION = os.getenv("ENABLE_KNOWLEDGE_EXTRACTION", "true").lower() == "true"
+
+if support_messages:
+    if ENABLE_RICH_RESOLUTION:
+        resolution_signal = detect_resolution_signal(support_messages)  # Uses ResolutionAnalyzer
+    else:
+        resolution_signal = detect_resolution_signal_simple(support_messages)  # Old 6-phrase version
+
+    if ENABLE_KNOWLEDGE_EXTRACTION:
+        knowledge = extract_knowledge(...)
+```
+
+**Recommendation**: Skip feature flags for Phase 1. The integration is low-risk (pattern matching, not LLM) and the old code path is trivial to restore if needed.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **ResolutionAnalyzer wrapper**
+   - Verify backward-compatible output format
+   - Verify full analysis contains expected fields
+
+2. **KnowledgeExtractor wrapper**
+   - Verify subset of fields returned
+   - Verify None handling for empty support messages
+
+### Integration Tests
+
+1. **Pipeline end-to-end**
+   - Run pipeline on test conversation with support messages
+   - Verify `support_insights` populated in DB
+   - Verify classification unchanged (same accuracy)
+
+2. **Performance**
+   - Run async pipeline on 100 conversations
+   - Verify throughput unchanged (>5 conv/sec)
+
+---
+
+## Acceptance Criteria
+
+- [ ] `detect_resolution_signal()` uses `ResolutionAnalyzer` internally
+- [ ] `support_insights` column populated with resolution analysis
+- [ ] `support_insights` column populated with knowledge extraction
+- [ ] Existing tests pass (no regression)
+- [ ] Async throughput unchanged (>5 conv/sec on 100 conversations)
+- [ ] No new database migrations required
+
+---
+
+## Agent Assignments
+
+### Marcus (Backend)
+
+**Owns**:
+
+- `src/two_stage_pipeline.py` (integration changes)
+- `src/db/classification_storage.py` (support_insights storage)
+
+**Creates**:
+
+- Helper functions: `get_full_resolution_analysis()`, `extract_knowledge()`
+
+**Does not touch**:
+
+- `src/resolution_analyzer.py` (already complete)
+- `src/knowledge_extractor.py` (already complete)
+
+**Acceptance**:
+
+- Pipeline stores `support_insights` for conversations with support messages
+- Backward compatibility: Stage 2 receives same resolution signal format
+- Tests pass, throughput unchanged
+
+### Kenji (Testing)
+
+**Creates**:
+
+- Unit tests for new helper functions
+- Integration test for `support_insights` storage
+
+**Acceptance**:
+
+- 100% coverage on new code paths
+- Performance test confirms no degradation
+
+---
+
+## Alternatives Considered
+
+### A. Separate Database Columns
+
+```sql
+ADD COLUMN resolution_analysis JSONB;
+ADD COLUMN knowledge_extraction JSONB;
+```
+
+**Rejected**: Requires migration, `support_insights` already exists for this purpose.
+
+### B. Call in Stage 1
+
+**Rejected**: Stage 1 has no support messages. Resolution analysis requires support context.
+
+### C. Run in Parallel with Stage 2 LLM
+
+```python
+resolution_task = asyncio.create_task(run_resolution_analysis(...))
+stage2_task = asyncio.create_task(classify_stage2_async(...))
+resolution, stage2 = await asyncio.gather(resolution_task, stage2_task)
+```
+
+**Rejected**: Over-engineering. Resolution analysis is <1ms, not worth the complexity. Knowledge extraction depends on Stage 2 result anyway.
+
+### D. Feature Flags
+
+**Deferred**: Not needed for Phase 1 given low risk. Can add later if issues emerge.
+
+---
+
+## References
+
+- Previous decision: `.claude/decisions/milestone-5-pr3-architecture.md`
+- ResolutionAnalyzer: `src/resolution_analyzer.py`
+- KnowledgeExtractor: `src/knowledge_extractor.py`
+- Pattern config: `config/resolution_patterns.json`
+- Migration: `src/db/migrations/001_add_two_stage_classification.sql`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ BEFORE these actions, STOP and answer:
 | **After Round 1 review**            | Who wrote the code I'm fixing?        | Route to original dev       |
 | **Creating PR**                     | Build + tests pass?                   | Fix before PR               |
 | **PR with prompt/pipeline changes** | Functional test run and verified?     | Run test, attach evidence   |
+| **Executing architect output**      | Is it deleting code not in scope?     | Flag for user approval      |
 | **Session ending**                  | BACKLOG_FLAGs to file? TODOs in code? | Review and file issues      |
 
 ---

--- a/docs/process-playbook/agents/coordination-patterns.md
+++ b/docs/process-playbook/agents/coordination-patterns.md
@@ -21,6 +21,7 @@ Ask these questions before parallelizing ANY work:
 ## How to Deploy Agents
 
 **Sequential with handoff:**
+
 ```
 // Architect designs first
 Agent(Architect): "Design the API contract for [feature]..."
@@ -30,6 +31,7 @@ Agent(Developer): "Implement the API that Architect designed: [paste contract]"
 ```
 
 **Parallel deployment:**
+
 ```
 // Launch multiple agents in parallel
 Agent(Backend, run_in_background=true)
@@ -41,16 +43,17 @@ Agent(Frontend, run_in_background=true)
 
 ## Scaling Guidance
 
-| Task Complexity | Agents | Example |
-|-----------------|--------|---------|
-| Simple fix | 0-1 | Fix typo, add field |
-| Single feature | 1-2 | Add button + API endpoint |
-| Cross-cutting feature | 2-4 | New workflow with UI + backend + tests |
-| Major refactor | 3-5 | Restructure module boundaries |
+| Task Complexity       | Agents | Example                                |
+| --------------------- | ------ | -------------------------------------- |
+| Simple fix            | 0-1    | Fix typo, add field                    |
+| Single feature        | 1-2    | Add button + API endpoint              |
+| Cross-cutting feature | 2-4    | New workflow with UI + backend + tests |
+| Major refactor        | 3-5    | Restructure module boundaries          |
 
 **The 2x Rule**: If parallelization won't save at least 2x the coordination overhead, do it yourself.
 
 **Agent Count Sweet Spots**:
+
 - **2-3 agents**: Easy, minimal overhead
 - **4-5 agents**: Sweet spot for complex features
 - **6+ agents**: Danger zone - coordination cost explodes
@@ -164,14 +167,14 @@ Agents repeat mistakes without memory. Memory retrieval surfaces past learnings 
 
 ### Keywords by Domain
 
-| Agent Type | Typical Keywords |
-|------------|------------------|
-| Prompt/AI | prompt-engineering, examples, constraints |
-| Backend | schema, repository, async, database |
-| Frontend | hooks, components, memoization |
-| Tests | coverage, edge-cases, mocking |
-| Architecture | architecture, boundaries, conflicts |
-| Reviewers | proxy-metrics, quality, security |
+| Agent Type   | Typical Keywords                          |
+| ------------ | ----------------------------------------- |
+| Prompt/AI    | prompt-engineering, examples, constraints |
+| Backend      | schema, repository, async, database       |
+| Frontend     | hooks, components, memoization            |
+| Tests        | coverage, edge-cases, mocking             |
+| Architecture | architecture, boundaries, conflicts       |
+| Reviewers    | proxy-metrics, quality, security          |
 
 ---
 
@@ -179,19 +182,19 @@ Agents repeat mistakes without memory. Memory retrieval surfaces past learnings 
 
 ### Simple Conflicts (Resolve Yourself)
 
-| Conflict Type | Default Resolution |
-|---------------|-------------------|
+| Conflict Type           | Default Resolution                  |
+| ----------------------- | ----------------------------------- |
 | Type/interface mismatch | Backend owns types, frontend adapts |
-| Same file edited | Review both, pick best or combine |
+| Same file edited        | Review both, pick best or combine   |
 
 ### Complex Conflicts (Get Architecture Help)
 
-| Conflict Type | When to Escalate |
-|---------------|------------------|
-| Design disagreement | Two agents solved the problem differently |
-| Domain boundary unclear | Both agents think they own the file |
-| Contract can't be reconciled | Components need different shapes |
-| Quality vs other tradeoffs | Need judgment call |
+| Conflict Type                | When to Escalate                          |
+| ---------------------------- | ----------------------------------------- |
+| Design disagreement          | Two agents solved the problem differently |
+| Domain boundary unclear      | Both agents think they own the file       |
+| Contract can't be reconciled | Components need different shapes          |
+| Quality vs other tradeoffs   | Need judgment call                        |
 
 ### Always Escalate to User When:
 
@@ -207,13 +210,13 @@ Agents repeat mistakes without memory. Memory retrieval surfaces past learnings 
 
 Establish clear ownership. Example structure:
 
-| Domain | Owner |
-|--------|-------|
-| `src/app/api/`, database, repositories | Backend Agent |
-| `src/components/`, pages, hooks | Frontend Agent |
+| Domain                                 | Owner           |
+| -------------------------------------- | --------------- |
+| `src/app/api/`, database, repositories | Backend Agent   |
+| `src/components/`, pages, hooks        | Frontend Agent  |
 | `src/lib/agents/`, prompts, evaluation | AI/Prompt Agent |
-| `*.test.ts`, test utilities | Test Agent |
-| `docs/`, agent profiles | Docs Agent |
+| `*.test.ts`, test utilities            | Test Agent      |
+| `docs/`, agent profiles                | Docs Agent      |
 
 **Customize this for your project structure.**
 
@@ -221,22 +224,23 @@ Establish clear ownership. Example structure:
 
 ## Failure Modes
 
-| Failure | Prevention | Recovery |
-|---------|------------|----------|
-| **Duplicate work** | Define boundaries upfront | Pick better implementation |
-| **Agent blocked waiting** | Identify dependencies upfront | Provide mock/stub, or sequence |
-| **Silent failure** (wrong but "done") | Specific acceptance criteria | Validate before accepting |
-| **Same file chaos** | Assign exclusive file ownership | Human merges carefully |
-| **Context rot** | Brief agents with current state | Re-brief if specs change |
-| **Skipped tests** | Test gate checklist | Revert, add tests, re-merge |
-| **Skipped reflections** | Deploy docs agent after merge | Go back and run it |
-| **Skipped architecture** | Default to Pattern 1 | If conflicts arise, escalate |
+| Failure                               | Prevention                      | Recovery                       |
+| ------------------------------------- | ------------------------------- | ------------------------------ |
+| **Duplicate work**                    | Define boundaries upfront       | Pick better implementation     |
+| **Agent blocked waiting**             | Identify dependencies upfront   | Provide mock/stub, or sequence |
+| **Silent failure** (wrong but "done") | Specific acceptance criteria    | Validate before accepting      |
+| **Same file chaos**                   | Assign exclusive file ownership | Human merges carefully         |
+| **Context rot**                       | Brief agents with current state | Re-brief if specs change       |
+| **Skipped tests**                     | Test gate checklist             | Revert, add tests, re-merge    |
+| **Skipped reflections**               | Deploy docs agent after merge   | Go back and run it             |
+| **Skipped architecture**              | Default to Pattern 1            | If conflicts arise, escalate   |
 
 ---
 
 ## Architecture Review Gate
 
 **When to use**: Before executing any multi-agent implementation plan that:
+
 - Touches critical paths (evaluators, metrics, core logic)
 - Has multiple systems integrating
 - Has non-obvious data flow between agents
@@ -255,6 +259,7 @@ Establish clear ownership. Example structure:
 | **Security** | Security-adjacent (auth, user data, external APIs) |
 
 **Process flow**:
+
 ```
 Architect designs -> Quality + Pragmatist validate plan -> Amend if needed -> Execute
 ```
@@ -270,8 +275,39 @@ Stop and ask when:
 - Tradeoff between security, performance, UX
 - You're unsure which agent's approach is right
 - Build fails after integration and you can't figure out why
+- **Architect recommends DELETION of functional code not in original scope**
 
 **What to provide**: What's conflicting, what you recommend, why, and alternatives considered.
+
+---
+
+## Architect Output Review Gate
+
+**MANDATORY**: When an architect recommends **deleting functional code** that wasn't explicitly scoped for removal in the original task, **flag for user approval before executing**.
+
+| Architect Output                          | Action                     |
+| ----------------------------------------- | -------------------------- |
+| Add new code                              | Execute directly           |
+| Modify existing code                      | Execute directly           |
+| Refactor without removal                  | Execute directly           |
+| **Delete functional code (in scope)**     | Execute directly           |
+| **Delete functional code (NOT in scope)** | **FLAG FOR USER APPROVAL** |
+
+**Why this gate exists**: Deletions are irreversible and may have non-obvious downstream impacts. The user should explicitly approve scope expansion to include deletion.
+
+**How to flag**:
+
+```
+Architect recommends deleting [X, Y, Z] because [rationale].
+This deletion was not in the original scope.
+
+Options:
+A) Approve deletion
+B) Keep the code
+C) Integrate instead of delete
+
+Which approach?
+```
 
 ---
 
@@ -296,12 +332,12 @@ From [Anthropic's research](https://www.anthropic.com/engineering/multi-agent-re
 
 ## Summary
 
-| Stage | Action |
-|-------|--------|
-| Planning | Decide: solo, sequence, or parallel |
+| Stage          | Action                                        |
+| -------------- | --------------------------------------------- |
+| Planning       | Decide: solo, sequence, or parallel           |
 | Pre-deployment | Retrieve memories, check context requirements |
-| Briefing | Use task spec checklist - be explicit |
-| Execution | Track file ownership in touch log |
-| Integration | Resolve conflicts with clear rules |
-| Review | Route fixes to original dev |
-| Post-merge | Collect reflections, update profiles |
+| Briefing       | Use task spec checklist - be explicit         |
+| Execution      | Track file ownership in touch log             |
+| Integration    | Resolve conflicts with clear rules            |
+| Review         | Route fixes to original dev                   |
+| Post-merge     | Collect reflections, update profiles          |

--- a/tests/test_pipeline_integration_insights.py
+++ b/tests/test_pipeline_integration_insights.py
@@ -1,0 +1,521 @@
+"""
+Tests for ResolutionAnalyzer and KnowledgeExtractor Integration.
+
+Tests the integration of resolution analysis and knowledge extraction into
+the two-stage classification pipeline.
+
+Run with: pytest tests/test_pipeline_integration_insights.py -v
+"""
+
+import pytest
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+import sys
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from two_stage_pipeline import (
+    detect_resolution_signal,
+    get_full_resolution_analysis,
+    extract_knowledge,
+)
+
+
+# -----------------------------------------------------------------------------
+# Unit Tests for Helper Functions
+# -----------------------------------------------------------------------------
+
+class TestDetectResolutionSignal:
+    """Test detect_resolution_signal backward compatibility."""
+
+    def test_detect_resolution_signal_backward_compatible(self):
+        """Verify simple format returned for backward compatibility."""
+        support_messages = [
+            "Thanks for reaching out!",
+            "I've processed your refund and it should appear in 3-5 business days."
+        ]
+
+        result = detect_resolution_signal(support_messages)
+
+        # Should return simple format: {"action": str, "signal": str}
+        assert result is not None
+        assert "action" in result
+        assert "signal" in result
+        assert isinstance(result["action"], str)
+        assert isinstance(result["signal"], str)
+
+    def test_detect_resolution_signal_empty_messages(self):
+        """Verify None handling for empty messages."""
+        assert detect_resolution_signal([]) is None
+        assert detect_resolution_signal(None) is None
+
+    def test_detect_resolution_signal_no_patterns(self):
+        """Verify None returned when no resolution patterns found."""
+        support_messages = [
+            "Thanks for reaching out!",
+            "Can you provide more details?"
+        ]
+
+        result = detect_resolution_signal(support_messages)
+        assert result is None
+
+    def test_detect_resolution_signal_multiple_patterns(self):
+        """Verify all messages are analyzed for resolution patterns."""
+        support_messages = [
+            "I've created a ticket for engineering.",  # Has pattern
+            "Can you provide more details?"  # No pattern
+        ]
+
+        result = detect_resolution_signal(support_messages)
+        # Should detect ticket_created from first message
+        assert result is not None
+        assert result["action"] == "ticket_created"
+
+    def test_detect_resolution_signal_various_phrases(self):
+        """Test detection of various resolution phrases from resolution_patterns.json."""
+        test_cases = [
+            ("I've processed your refund", "refund_processed", "processed your refund"),
+            ("I've created a ticket for engineering", "ticket_created", "created a ticket"),
+            ("Here's the help doc", "docs_link_sent", "here's the help doc"),
+            ("Not currently available", "feature_not_available", "not currently available"),
+            ("I've reset your password", "password_reset", "reset your password"),
+        ]
+
+        for message, expected_action, expected_keyword in test_cases:
+            result = detect_resolution_signal([message])
+            assert result is not None, f"Expected to detect pattern in: {message}"
+            assert result["action"] == expected_action
+            assert expected_keyword in result["signal"].lower()
+
+
+class TestGetFullResolutionAnalysis:
+    """Test get_full_resolution_analysis format."""
+
+    def test_get_full_resolution_analysis_format(self):
+        """Verify full analysis structure."""
+        support_messages = [
+            "Thanks for reaching out!",
+            "I've processed your refund and it should appear in 3-5 business days."
+        ]
+
+        with patch('two_stage_pipeline.get_resolution_analyzer') as mock_get_analyzer:
+            # Mock the analyzer
+            mock_analyzer = Mock()
+            mock_analyzer.analyze_conversation.return_value = {
+                "primary_action": {
+                    "action": "refund_processed",
+                    "category": "billing",
+                    "conversation_type": "billing_question",
+                    "action_category": "billing_resolution",
+                    "matched_keyword": "refund"
+                },
+                "all_actions": [
+                    {
+                        "action": "refund_processed",
+                        "category": "billing",
+                        "matched_keyword": "refund"
+                    }
+                ],
+                "action_count": 1,
+                "categories": ["billing"],
+                "suggested_type": "billing_question"
+            }
+            mock_get_analyzer.return_value = mock_analyzer
+
+            result = get_full_resolution_analysis(support_messages)
+
+            # Verify expected keys
+            assert "primary_action" in result
+            assert "action_category" in result
+            assert "all_actions" in result
+            assert "categories" in result
+            assert "suggested_type" in result
+            assert "matched_keywords" in result
+
+            # Verify types
+            assert result["primary_action"] == "refund_processed"
+            assert result["action_category"] == "billing_resolution"
+            assert isinstance(result["all_actions"], list)
+            assert isinstance(result["categories"], list)
+            assert result["suggested_type"] == "billing_question"
+            assert isinstance(result["matched_keywords"], list)
+
+    def test_get_full_resolution_analysis_no_actions(self):
+        """Verify handling when no actions detected."""
+        support_messages = ["Thanks for reaching out!"]
+
+        with patch('two_stage_pipeline.get_resolution_analyzer') as mock_get_analyzer:
+            mock_analyzer = Mock()
+            mock_analyzer.analyze_conversation.return_value = {
+                "primary_action": None,
+                "all_actions": [],
+                "action_count": 0,
+                "categories": [],
+                "suggested_type": None
+            }
+            mock_get_analyzer.return_value = mock_analyzer
+
+            result = get_full_resolution_analysis(support_messages)
+
+            assert result["primary_action"] is None
+            assert result["action_category"] is None
+            assert result["all_actions"] == []
+            assert result["categories"] == []
+            assert result["suggested_type"] is None
+            assert result["matched_keywords"] == []
+
+    def test_get_full_resolution_analysis_empty_messages(self):
+        """Verify empty dict returned for empty messages."""
+        assert get_full_resolution_analysis([]) == {}
+        assert get_full_resolution_analysis(None) == {}
+
+
+class TestExtractKnowledge:
+    """Test extract_knowledge format."""
+
+    def test_extract_knowledge_format(self):
+        """Verify knowledge structure."""
+        customer_message = "I can't cancel my subscription"
+        support_messages = [
+            "I'm sorry you're looking to cancel. Could you share why?",
+            "I've gone ahead and initialized that cancellation for you."
+        ]
+
+        with patch('two_stage_pipeline.get_knowledge_extractor') as mock_get_extractor:
+            mock_extractor = Mock()
+            mock_extractor.extract_from_conversation.return_value = {
+                "conversation_type": "billing_question",
+                "root_cause": "Customer wants to cancel subscription",
+                "solution_provided": "I've gone ahead and initialized that cancellation for you",
+                "product_mentions": ["subscription"],
+                "feature_mentions": ["billing"],
+                "customer_terminology": ["cancel subscription"],
+                "support_terminology": ["initialized cancellation"],
+                "self_service_gap": True,
+                "gap_evidence": "Support manually handled cancel - could be self-service"
+            }
+            mock_get_extractor.return_value = mock_extractor
+
+            result = extract_knowledge(
+                customer_message,
+                support_messages,
+                "billing_question"
+            )
+
+            # Verify expected keys (subset for storage)
+            assert "root_cause" in result
+            assert "solution_provided" in result
+            assert "product_mentions" in result
+            assert "feature_mentions" in result
+            assert "self_service_gap" in result
+            assert "gap_evidence" in result
+
+            # Should NOT include verbose fields
+            assert "customer_terminology" not in result
+            assert "support_terminology" not in result
+
+            # Verify values
+            assert result["self_service_gap"] is True
+            assert "cancel" in result["gap_evidence"]
+
+    def test_extract_knowledge_empty_messages(self):
+        """Verify empty dict returned for empty messages."""
+        assert extract_knowledge("test", [], "billing_question") == {}
+        assert extract_knowledge("test", None, "billing_question") == {}
+
+    def test_extract_knowledge_no_self_service_gap(self):
+        """Verify handling when no self-service gap detected."""
+        customer_message = "How do I reset my password?"
+        support_messages = [
+            "You can reset your password by visiting the login page and clicking 'Forgot Password'."
+        ]
+
+        with patch('two_stage_pipeline.get_knowledge_extractor') as mock_get_extractor:
+            mock_extractor = Mock()
+            mock_extractor.extract_from_conversation.return_value = {
+                "conversation_type": "how_to_question",
+                "root_cause": None,
+                "solution_provided": "You can reset your password by visiting the login page",
+                "product_mentions": [],
+                "feature_mentions": ["password"],
+                "customer_terminology": ["reset password"],
+                "support_terminology": ["forgot password"],
+                "self_service_gap": False,
+                "gap_evidence": None
+            }
+            mock_get_extractor.return_value = mock_extractor
+
+            result = extract_knowledge(
+                customer_message,
+                support_messages,
+                "how_to_question"
+            )
+
+            assert result["self_service_gap"] is False
+            assert result["gap_evidence"] is None
+
+
+# -----------------------------------------------------------------------------
+# Integration Tests
+# -----------------------------------------------------------------------------
+
+class TestSupportInsightsIntegration:
+    """Test support_insights structure in pipeline results."""
+
+    def test_support_insights_structure_with_messages(self):
+        """Verify support_insights structure when support messages exist."""
+        from two_stage_pipeline import extract_support_messages
+
+        # Test extract_support_messages helper
+        raw_conversation = {
+            "conversation_parts": {
+                "conversation_parts": [
+                    {
+                        "part_type": "comment",
+                        "author": {"type": "admin"},
+                        "body": "I'm sorry you're looking to cancel. Could you share why?"
+                    },
+                    {
+                        "part_type": "comment",
+                        "author": {"type": "admin"},
+                        "body": "I've gone ahead and processed your refund."
+                    },
+                    {
+                        "part_type": "comment",
+                        "author": {"type": "user"},  # Should be filtered out
+                        "body": "Thank you!"
+                    }
+                ]
+            }
+        }
+
+        messages = extract_support_messages(raw_conversation)
+
+        # Should only extract admin messages
+        assert len(messages) == 2
+        assert "cancel" in messages[0].lower()
+        assert "refund" in messages[1].lower()
+
+    def test_support_insights_structure_no_messages(self):
+        """Verify support_insights handling when no support messages."""
+        from two_stage_pipeline import extract_support_messages
+
+        raw_conversation = {
+            "conversation_parts": {
+                "conversation_parts": []
+            }
+        }
+
+        messages = extract_support_messages(raw_conversation)
+        assert messages == []
+
+    def test_support_insights_backward_compatibility(self):
+        """Verify resolution_signal format unchanged (backward compatibility)."""
+        support_messages = [
+            "I've created a ticket for engineering to investigate this issue."
+        ]
+
+        # Test the simple detect_resolution_signal
+        result = detect_resolution_signal(support_messages)
+
+        # Should return simple format: {"action": str, "signal": str}
+        assert result is not None
+        assert "action" in result
+        assert "signal" in result
+        assert result["action"] == "ticket_created"
+        assert "created a ticket" in result["signal"].lower()
+
+        # Test the full analysis
+        full_result = get_full_resolution_analysis(support_messages)
+
+        # Should have more detailed structure
+        assert "primary_action" in full_result
+        assert "action_category" in full_result
+        assert "all_actions" in full_result
+        assert full_result["primary_action"] == "ticket_created"
+        assert full_result["action_category"] == "escalation"
+
+    def test_integration_extract_support_messages_various_authors(self):
+        """Test extract_support_messages with various author types."""
+        raw_conversation = {
+            "conversation_parts": {
+                "conversation_parts": [
+                    {
+                        "part_type": "comment",
+                        "author": {"type": "admin"},
+                        "body": "Admin message 1"
+                    },
+                    {
+                        "part_type": "comment",
+                        "author": {"type": "bot"},
+                        "body": "Bot message"
+                    },
+                    {
+                        "part_type": "comment",
+                        "author": {"type": "user"},
+                        "body": "User message"
+                    },
+                    {
+                        "part_type": "note",  # Not a comment
+                        "author": {"type": "admin"},
+                        "body": "Admin note"
+                    }
+                ]
+            }
+        }
+
+        from two_stage_pipeline import extract_support_messages
+        messages = extract_support_messages(raw_conversation)
+
+        # Should only extract admin and bot comments (not notes, not user)
+        assert len(messages) == 2
+        assert "Admin message 1" in messages
+        assert "Bot message" in messages
+
+
+# -----------------------------------------------------------------------------
+# Database Integration Tests
+# -----------------------------------------------------------------------------
+
+class TestSupportInsightsDBStorage:
+    """Test support_insights stored in DB (integration with storage layer)."""
+
+    def test_support_insights_stored_in_db(self):
+        """Verify support_insights can be stored in classification_results table."""
+        # This test verifies the data structure is compatible with DB storage
+        # Actual DB test would require database fixture
+
+        sample_support_insights = {
+            "resolution_analysis": {
+                "primary_action": "refund_processed",
+                "action_category": "billing_resolution",
+                "all_actions": ["refund_processed"],
+                "categories": ["billing"],
+                "suggested_type": "billing_question",
+                "matched_keywords": ["refund"]
+            },
+            "knowledge": {
+                "root_cause": "Customer wants refund",
+                "solution_provided": "I've processed your refund",
+                "product_mentions": ["subscription"],
+                "feature_mentions": ["billing"],
+                "self_service_gap": True,
+                "gap_evidence": "Support manually handled refund"
+            }
+        }
+
+        # Verify structure is JSON-serializable (required for JSONB storage)
+        import json
+        try:
+            json_str = json.dumps(sample_support_insights)
+            restored = json.loads(json_str)
+            assert restored == sample_support_insights
+        except (TypeError, ValueError) as e:
+            pytest.fail(f"support_insights not JSON-serializable: {e}")
+
+    def test_support_insights_empty_structure(self):
+        """Verify empty support_insights is valid."""
+        empty_insights = {
+            "resolution_analysis": {},
+            "knowledge": {}
+        }
+
+        import json
+        json_str = json.dumps(empty_insights)
+        restored = json.loads(json_str)
+        assert restored == empty_insights
+
+    def test_support_insights_null_values(self):
+        """Verify support_insights with null values is valid."""
+        null_insights = {
+            "resolution_analysis": {
+                "primary_action": None,
+                "action_category": None,
+                "all_actions": [],
+                "categories": [],
+                "suggested_type": None,
+                "matched_keywords": []
+            },
+            "knowledge": {
+                "root_cause": None,
+                "solution_provided": None,
+                "product_mentions": [],
+                "feature_mentions": [],
+                "self_service_gap": False,
+                "gap_evidence": None
+            }
+        }
+
+        import json
+        json_str = json.dumps(null_insights)
+        restored = json.loads(json_str)
+        assert restored == null_insights
+
+
+# -----------------------------------------------------------------------------
+# Edge Case Tests
+# -----------------------------------------------------------------------------
+
+class TestHelperEdgeCases:
+    """Test edge cases for helper functions."""
+
+    def test_detect_resolution_signal_handles_special_chars(self):
+        """Test handling of special characters in messages."""
+        support_messages = [
+            "I've processed your refund! 🎉"  # Use actual pattern from resolution_patterns.json
+        ]
+        result = detect_resolution_signal(support_messages)
+        assert result is not None
+        assert result["action"] == "refund_processed"
+
+    def test_detect_resolution_signal_case_insensitive(self):
+        """Test case-insensitive pattern matching."""
+        support_messages = [
+            "I've PROCESSED YOUR REFUND."  # Use actual pattern from resolution_patterns.json
+        ]
+        result = detect_resolution_signal(support_messages)
+        assert result is not None
+        assert result["action"] == "refund_processed"
+
+    def test_get_full_resolution_analysis_with_multiple_actions(self):
+        """Test handling of multiple detected actions."""
+        support_messages = [
+            "I've created a ticket for engineering and sent you the help doc."
+        ]
+
+        with patch('two_stage_pipeline.get_resolution_analyzer') as mock_get_analyzer:
+            mock_analyzer = Mock()
+            mock_analyzer.analyze_conversation.return_value = {
+                "primary_action": {
+                    "action": "ticket_created",
+                    "category": "escalation",
+                    "conversation_type": "product_issue",
+                    "action_category": "escalation",
+                    "matched_keyword": "ticket"
+                },
+                "all_actions": [
+                    {
+                        "action": "ticket_created",
+                        "category": "escalation",
+                        "matched_keyword": "ticket"
+                    },
+                    {
+                        "action": "docs_link_sent",
+                        "category": "guidance",
+                        "matched_keyword": "help doc"
+                    }
+                ],
+                "action_count": 2,
+                "categories": ["escalation", "guidance"],
+                "suggested_type": "product_issue"
+            }
+            mock_get_analyzer.return_value = mock_analyzer
+
+            result = get_full_resolution_analysis(support_messages)
+
+            assert len(result["all_actions"]) == 2
+            assert "ticket_created" in result["all_actions"]
+            assert "docs_link_sent" in result["all_actions"]
+            assert len(result["categories"]) == 2
+            assert len(result["matched_keywords"]) == 2


### PR DESCRIPTION
## Summary

- Wire existing `ResolutionAnalyzer` and `KnowledgeExtractor` modules into the two-stage classification pipeline
- Enrich the `support_insights` JSONB column with resolution analysis and knowledge extraction data
- Add 21 unit tests covering all new functionality
- Add Architect Output Review Gate for deletion approval workflow

## Changes

| File | Change |
|------|--------|
| `src/two_stage_pipeline.py` | Replace `detect_resolution_signal()` with `ResolutionAnalyzer`, add helper functions, build `support_insights` in both sync/async paths |
| `src/db/classification_storage.py` | Update comments for clarity on storage paths |
| `tests/test_pipeline_integration_insights.py` | Add 21 tests for new functionality |
| `CLAUDE.md` | Add Tech Lead Gate for architect deletion approval |
| `docs/process-playbook/agents/coordination-patterns.md` | Add Architect Output Review Gate section |
| `.claude/decisions/` | Architecture decision documents |

## support_insights Schema

```json
{
  "resolution_analysis": {
    "primary_action": "refund_processed",
    "action_category": "billing_resolution",
    "all_actions": ["refund_processed"],
    "categories": ["billing"],
    "suggested_type": "billing_question",
    "matched_keywords": ["processed your refund"]
  },
  "knowledge": {
    "root_cause": "billing sync issue",
    "solution_provided": "processed refund",
    "product_mentions": ["Pro plan"],
    "feature_mentions": ["billing"],
    "self_service_gap": true,
    "gap_evidence": "Support manually cancelled"
  }
}
```

## Test Plan

- [x] 21 unit tests pass: `pytest tests/test_pipeline_integration_insights.py -v`
- [x] Existing tests unaffected: `pytest tests/ -v`
- [x] 5-personality review converged (Round 2: 5/5 APPROVE)

## Review Convergence

| Reviewer | Round 1 | Round 2 |
|----------|---------|---------|
| Reginald | REQUEST_CHANGES | APPROVE ✓ |
| Sanjay | APPROVE | APPROVE ✓ |
| Quinn | REQUEST_CHANGES | APPROVE ✓ |
| Dmitri | REQUEST_CHANGES | APPROVE ✓ |
| Maya | REQUEST_CHANGES | APPROVE ✓ |

**CONVERGED**

Closes #78, Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)