### PR TITLE
feat: Add LLM-based story content generation

### DIFF
--- a/docs/architecture/story-content-generation.md
+++ b/docs/architecture/story-content-generation.md
@@ -1,0 +1,424 @@
+# Story Content Generation Architecture
+
+> Architecture designed by Priya, updated with requirements from tech lead review and Quality/Pragmatist architecture review.
+
+## Overview
+
+This document defines the architecture for LLM-generated story content, replacing the current direct use of `user_intent` with synthesized, purpose-appropriate outputs.
+
+**Problem**: The raw `user_intent` field from theme extraction describes what the user was doing ("The user was trying to upload pins to their drafts.") but is being used directly in places where it doesn't fit:
+
+1. **Story Title** - Should be outcome-focused: "Fix pin upload failures when saving to drafts"
+2. **User Story "I want" clause** - Should be first-person infinitive: "to be able to upload pins to my drafts without errors"
+3. **User Story "As a" clause** - Currently hardcoded to "Tailwind user", should be context-specific
+4. **User Story "So that" clause** - Currently hardcoded to "achieve my goals without friction", should be context-specific
+5. **AI Agent Goal** - Should be actionable with success criteria: "Resolve the pin upload failure where users receive Server 0 response code. Success: uploads complete, pins appear in drafts."
+
+## Components
+
+### 1. StoryContentGenerator (New Module)
+
+**Location**: `src/story_tracking/services/story_content_generator.py`
+
+**Purpose**: Single LLM call that generates all synthesized outputs from grouped conversation data.
+
+### 2. Integration Point
+
+**Location**: `src/story_tracking/services/story_creation_service.py`
+
+**Hook**: `_generate_title()` method (line 1907) is the primary hook point. The generator will be called once before title/description generation, with results used by both.
+
+## Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                     Story Creation Flow (Proposed)                          │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  conversations ──► _build_theme_data() ──► StoryContentGenerator.generate()│
+│                                                    │                        │
+│                    ┌───────────────────────────────┼───────────────────────┐│
+│                    │            │           │      │       │               ││
+│                    ▼            ▼           ▼      ▼       ▼               ││
+│               [title]    [user_type]  [want]  [benefit]  [goal]            ││
+│                    │            │           │      │       │               ││
+│                    └───────────────────────────────┼───────────────────────┘│
+│                                                    │                        │
+│                                        GeneratedStoryContent                │
+│                                                    │                        │
+│                              ┌─────────────────────┼─────────────────────┐  │
+│                              ▼                     ▼                     ▼  │
+│                   _generate_title()    DualStoryFormatter     DualStoryFormatter│
+│                   (uses .title)        ._format_user_story()  .format_ai_section()│
+│                                        (uses all 4 fields)    (uses .goal)  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Interface Contracts
+
+### Input Model
+
+```python
+@dataclass
+class StoryContentInput:
+    """Input data for story content generation."""
+
+    # From grouped conversations
+    user_intents: List[str]  # All user_intent values from conversations
+    symptoms: List[str]      # All symptoms (deduplicated)
+    issue_signature: str     # The theme signature
+
+    # Context
+    classification_category: str  # product_issue, feature_request, how_to_question, account_issue, billing_question
+    product_area: str
+    component: str
+
+    # Optional: Additional context
+    root_cause_hypothesis: Optional[str] = None
+    affected_flow: Optional[str] = None
+    excerpts: Optional[List[str]] = None  # Conversation excerpts for additional context
+```
+
+### Output Model
+
+```python
+@dataclass
+class GeneratedStoryContent:
+    """LLM-generated story content."""
+
+    title: str
+    """
+    Outcome-focused story title.
+
+    Format: Action verb + specific problem
+    Examples:
+      - "Fix pin upload failures when saving to drafts"
+      - "Add bulk scheduling for Instagram Reels"
+      - "Clarify SmartSchedule timezone settings"
+
+    Derived from classification_category:
+      - product_issue: "Fix [symptom]"
+      - feature_request: "Add [capability]"
+      - how_to_question: "Clarify [topic] documentation"
+      - account_issue: "Resolve [account problem]"
+      - billing_question: "Clarify [billing topic]"
+    """
+
+    user_type: str
+    """
+    The persona for "As a [user_type]" in user story.
+
+    Examples:
+      - "content creator managing multiple Pinterest accounts"
+      - "social media manager scheduling bulk content"
+      - "new Tailwind user learning pin scheduling"
+
+    Should be specific to the context, not generic "Tailwind user".
+    """
+
+    user_story_want: str
+    """
+    First-person infinitive clause for "I want..." in user story.
+
+    Format: "to be able to [action] [context] [without error/successfully]"
+    Examples:
+      - "to be able to upload pins to my drafts without errors"
+      - "to schedule posts for multiple accounts in one action"
+      - "to understand how timezone settings affect my schedule"
+
+    Must be grammatically correct when inserted into:
+    "As a [user_type], I want [user_story_want], So that [benefit]"
+    """
+
+    user_story_benefit: str
+    """
+    The benefit clause for "So that [benefit]" in user story.
+
+    Examples:
+      - "I can maintain my posting schedule without interruption"
+      - "I save time on repetitive scheduling tasks"
+      - "I can optimize my posting times for engagement"
+
+    Should be specific to the problem, not generic "achieve my goals".
+    """
+
+    ai_agent_goal: str
+    """
+    Actionable goal with success criteria for AI agent.
+
+    Format: "[Action verb] the [specific issue]. Success: [measurable criteria]"
+    Examples:
+      - "Resolve the pin upload failure where users receive Server 0 response code.
+         Success: uploads complete, pins appear in drafts within 5 seconds."
+      - "Implement bulk scheduling for Instagram Reels.
+         Success: user can select multiple reels and schedule with one action."
+
+    Must include:
+      - Specific action to take
+      - Explicit success criteria (observable, measurable)
+      - Boundaries (what's in/out of scope)
+    """
+
+```
+
+### Generator Interface
+
+```python
+class StoryContentGenerator:
+    """
+    Generates synthesized story content from grouped conversation data.
+
+    Uses a single LLM call to produce:
+    - Outcome-focused title
+    - Context-specific user type
+    - User story "I want" clause
+    - Context-specific benefit
+    - AI agent goal with success criteria
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-4o-mini",
+        prompt_template: str = None,  # Designed by Kai
+    ):
+        ...
+
+    def generate(
+        self,
+        content_input: StoryContentInput,
+        max_retries: int = 3,
+    ) -> GeneratedStoryContent:
+        """
+        Generate story content with retry logic.
+
+        Retries with exponential backoff on transient failures.
+        Falls back to mechanical defaults after retries exhausted.
+        """
+        ...
+```
+
+## LLM Prompt Structure
+
+**Owner: Kai (Prompt Engineering)**
+
+The prompt should be designed by Kai following these requirements:
+
+### Required Outputs (JSON Schema)
+
+```json
+{
+  "title": "string (max 80 chars, action verb first)",
+  "user_type": "string (specific persona, not generic)",
+  "user_story_want": "string (starts with 'to', first-person)",
+  "user_story_benefit": "string (specific outcome)",
+  "ai_agent_goal": "string (includes Success: criteria)"
+}
+```
+
+### Prompt Design Requirements
+
+1. **Title**:
+   - Outcome-focused, not action-focused
+   - Uses classification to pick appropriate verb (Fix, Add, Clarify, etc.)
+   - Max 80 characters, no trailing period
+
+2. **User Type**:
+   - Context-specific persona based on product area and symptoms
+   - More specific than "Tailwind user"
+   - Examples: "content creator", "social media manager", "business owner"
+
+3. **User Story Want**:
+   - First-person infinitive ("to be able to...")
+   - References specific action from user_intents
+   - Includes success qualifier
+
+4. **User Story Benefit**:
+   - Specific to the problem being solved
+   - Explains the "why" behind the request
+   - Not generic "achieve goals without friction"
+
+5. **AI Agent Goal**:
+   - Action verb first
+   - References specific symptoms/errors
+   - Includes explicit "Success:" criteria
+   - Optionally includes scope boundaries
+
+## File Boundaries
+
+### Files to Create
+
+| File                                                     | Owner  | Purpose                                     |
+| -------------------------------------------------------- | ------ | ------------------------------------------- |
+| `src/story_tracking/services/story_content_generator.py` | Marcus | New module with StoryContentGenerator class |
+| `src/prompts/story_content.py`                           | Kai    | Prompt template for content generation      |
+| `tests/story_tracking/test_story_content_generator.py`   | Marcus | Unit tests                                  |
+
+### Files to Modify
+
+| File                                                    | Owner  | Changes                                                                   |
+| ------------------------------------------------------- | ------ | ------------------------------------------------------------------------- |
+| `src/story_tracking/services/story_creation_service.py` | Marcus | Call generator, pass results to description                               |
+| `src/story_formatter.py`                                | Marcus | Use generated content in `_format_user_story()` and `format_ai_section()` |
+
+## Retry and Fallback Strategy
+
+### Retry Logic
+
+LLM calls use exponential backoff before falling back to mechanical defaults:
+
+```python
+def generate(self, content_input: StoryContentInput, max_retries: int = 3) -> GeneratedStoryContent:
+    """Generate with retry logic."""
+    base_delay = 1.0  # seconds
+
+    for attempt in range(max_retries):
+        try:
+            return self._call_llm(content_input)
+        except (RateLimitError, TimeoutError, TransientError) as e:
+            if attempt == max_retries - 1:
+                logger.warning(f"LLM generation failed after {max_retries} attempts: {e}")
+                return self._mechanical_fallback(content_input)
+            delay = base_delay * (2 ** attempt)  # 1s, 2s, 4s
+            time.sleep(delay)
+
+    return self._mechanical_fallback(content_input)
+```
+
+### Mechanical Fallbacks (Per Field)
+
+After retries exhausted, each field falls back to mechanical defaults (no LLM required):
+
+| Field                | Fallback Logic                                                                         |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| `title`              | Use `user_intent` if > 10 chars, else humanize signature ("pin_upload" → "Pin Upload") |
+| `user_type`          | Hardcode: `"Tailwind user"`                                                            |
+| `user_story_want`    | Use `user_intent` directly (grammatically awkward but matches current behavior)        |
+| `user_story_benefit` | Hardcode: `"achieve my goals without friction"`                                        |
+| `ai_agent_goal`      | `user_intent` + `" Fix the reported issue and restore expected functionality."`        |
+
+```python
+def _mechanical_fallback(self, content_input: StoryContentInput) -> GeneratedStoryContent:
+    """Purely mechanical fallback - no LLM involved."""
+    user_intent = content_input.user_intents[0] if content_input.user_intents else None
+    signature = content_input.issue_signature
+
+    return GeneratedStoryContent(
+        title=user_intent if user_intent and len(user_intent) > 10
+              else signature.replace("_", " ").title(),
+        user_type="Tailwind user",
+        user_story_want=user_intent or "use the product successfully",
+        user_story_benefit="achieve my goals without friction",
+        ai_agent_goal=f"{user_intent or signature}. Fix the reported issue and restore expected functionality.",
+    )
+```
+
+## Edge Case Handling
+
+| Scenario                       | Behavior                                                  |
+| ------------------------------ | --------------------------------------------------------- |
+| Empty `user_intents`           | Use first symptom as pseudo-intent, else use signature    |
+| Empty `symptoms`               | Generate from user_intents only (symptoms not required)   |
+| Both empty                     | Use signature-based defaults, log warning                 |
+| Unknown classification         | Map to `product_issue` (most common), log warning         |
+| Very long inputs (>4000 chars) | Truncate before LLM call to stay under token limits       |
+| Invalid JSON from LLM          | Retry (counted in retry budget), then mechanical fallback |
+| Partial JSON from LLM          | Use valid fields, mechanical fallback for missing fields  |
+
+## Testing Strategy
+
+### Unit Tests (Marcus)
+
+- Basic generation with valid input
+- All classification categories produce appropriate output
+- Title format validation (verb first, < 80 chars)
+- User story grammar validation
+- AI goal includes success criteria
+- Retry logic: transient failures trigger retries with backoff
+- Retry exhaustion: falls back to mechanical defaults after 3 attempts
+- Mechanical fallback: each field uses correct default
+- Edge cases: empty inputs, unknown categories, long inputs
+
+### Prompt Tests (Kai)
+
+- Prompt produces valid JSON for all categories
+- Output quality meets requirements
+- Edge cases (empty symptoms, no user_intent, etc.)
+
+### Integration Tests
+
+- Full flow from conversations to story
+- Orphan graduation uses same logic
+- Retry behavior under realistic failure scenarios
+
+## Agent Assignments
+
+### Kai (Prompt Engineering)
+
+**Creates**:
+
+- `src/prompts/story_content.py` - Prompt template
+
+**Acceptance Criteria**:
+
+- [ ] Prompt produces valid JSON for all 5 fields
+- [ ] Titles use category-appropriate action verbs
+- [ ] User types are context-specific, not generic
+- [ ] User story clauses are grammatically correct
+- [ ] Benefits are specific to the problem
+- [ ] AI goals include success criteria
+
+### Marcus (Backend)
+
+**Creates**:
+
+- `src/story_tracking/services/story_content_generator.py`
+- `tests/story_tracking/test_story_content_generator.py`
+
+**Modifies**:
+
+- `src/story_tracking/services/story_creation_service.py`
+- `src/story_formatter.py`
+
+**Acceptance Criteria**:
+
+- [ ] Generator integrates Kai's prompt
+- [ ] Results used for title, user story, and AI goal
+- [ ] Retry logic with exponential backoff (3 attempts)
+- [ ] Mechanical fallback per field after retries exhausted
+- [ ] Edge case handling (empty inputs, unknown categories)
+- [ ] Unit tests cover all methods including retry/fallback
+- [ ] Orphan graduation uses same logic
+
+## Implementation Plan
+
+1. **Phase 1: Prompt Design** (Kai)
+   - Design and test the LLM prompt
+   - Create `src/prompts/story_content.py`
+   - Verify outputs for all classification categories
+
+2. **Phase 2: Core Module** (Marcus)
+   - Create `story_content_generator.py`
+   - Integrate Kai's prompt
+   - Add unit tests
+
+3. **Phase 3: Integration** (Marcus)
+   - Modify `story_creation_service.py` to call generator
+   - Update `story_formatter.py` to use all generated fields
+   - Add retry logic and mechanical fallbacks
+
+4. **Phase 4: Testing** (Marcus + Kenji)
+   - Integration tests
+   - Functional test with real pipeline run
+
+## Orphan Graduation
+
+Same content generation logic applies when orphans graduate to stories. The generator is called with orphan data, and the resulting content is used to create the story.
+
+## Migration Considerations
+
+Not in scope for this feature. Architecture supports future migration by:
+
+- No schema changes required
+- Backward compatible fallback
+- Existing stories continue to work

--- a/src/api/routers/pipeline.py
+++ b/src/api/routers/pipeline.py
@@ -710,7 +710,7 @@ def _run_pm_review_and_story_creation(run_id: int, stop_checker: Callable[[], bo
             cur.execute("""
                 SELECT t.issue_signature, t.product_area, t.component,
                        t.conversation_id, t.user_intent, t.symptoms,
-                       t.affected_flow, c.source_body
+                       t.affected_flow, c.source_body, c.issue_type
                 FROM themes t
                 JOIN conversations c ON t.conversation_id = c.id
                 WHERE t.pipeline_run_id = %s
@@ -736,6 +736,7 @@ def _run_pm_review_and_story_creation(run_id: int, stop_checker: Callable[[], bo
             "symptoms": row["symptoms"],
             "affected_flow": row["affected_flow"],
             "excerpt": (row["source_body"] or "")[:500],
+            "classification_category": row["issue_type"],
         }
         conversation_data[row["conversation_id"]] = conv_dict
         groups[row["issue_signature"]].append(conv_dict)

--- a/src/prompts/__init__.py
+++ b/src/prompts/__init__.py
@@ -11,9 +11,26 @@ from .pm_review import (
     build_pm_review_prompt,
 )
 
+from .story_content import (
+    STORY_CONTENT_PROMPT,
+    StoryContentInput,
+    format_user_intents,
+    format_symptoms,
+    format_optional_context,
+    build_story_content_prompt,
+)
+
 __all__ = [
+    # PM Review
     "PM_REVIEW_PROMPT",
     "CONVERSATION_TEMPLATE",
     "format_conversations_for_review",
     "build_pm_review_prompt",
+    # Story Content
+    "STORY_CONTENT_PROMPT",
+    "StoryContentInput",
+    "format_user_intents",
+    "format_symptoms",
+    "format_optional_context",
+    "build_story_content_prompt",
 ]

--- a/src/prompts/story_content.py
+++ b/src/prompts/story_content.py
@@ -1,0 +1,277 @@
+"""
+Story Content Generation Prompt
+
+LLM prompt for generating synthesized story content from grouped conversation data.
+Produces outcome-focused titles, context-specific user stories, and AI agent goals.
+
+Owner: Kai (Prompt Engineering)
+Used by: StoryContentGenerator (Marcus - Backend)
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+# Story Content Generation Prompt Template
+# Uses OpenAI JSON mode for structured output
+STORY_CONTENT_PROMPT = '''You are a product manager synthesizing support conversations into actionable product stories for Tailwind, a social media scheduling tool.
+
+## Your Task
+
+Generate 5 fields that will be used in product tickets. Each field serves a specific purpose and has strict formatting requirements.
+
+## Input Context
+
+**Classification**: {classification_category}
+**Product Area**: {product_area}
+**Component**: {component}
+**Issue Signature**: {issue_signature}
+
+### What Users Were Trying To Do
+{user_intents_formatted}
+
+### What Went Wrong (Symptoms)
+{symptoms_formatted}
+
+{optional_context}
+
+## Output Requirements
+
+Generate valid JSON with these 5 fields:
+
+### 1. title (max 80 chars, no trailing period)
+
+**Format**: `[Action Verb] [specific problem/capability]`
+
+**Action verb based on category**:
+- product_issue: "Fix [symptom/error]"
+- feature_request: "Add [capability]"
+- how_to_question: "Clarify [topic] documentation"
+- account_issue: "Resolve [account problem]"
+- billing_question: "Clarify [billing topic]"
+
+**Examples**:
+- "Fix pin upload failures when saving to drafts"
+- "Add bulk scheduling for Instagram Reels"
+- "Clarify SmartSchedule timezone settings in help docs"
+- "Resolve Pinterest OAuth connection timeouts"
+
+**Bad examples** (avoid these patterns):
+- "User cannot upload pins" (passive, not outcome-focused)
+- "Pins not working" (too vague)
+- "Fix the issue with scheduling" (not specific)
+
+### 2. user_type (specific persona)
+
+**Format**: A specific persona description based on product area and context.
+
+**Good examples**:
+- "content creator managing multiple Pinterest accounts"
+- "social media manager scheduling bulk content for clients"
+- "e-commerce owner using Tailwind for product promotion"
+- "marketing team member tracking Pinterest analytics"
+- "new Tailwind user learning the scheduling workflow"
+
+**Bad examples** (never use):
+- "Tailwind user" (too generic)
+- "user" (meaningless)
+- "customer" (not persona-based)
+
+### 3. user_story_want (first-person infinitive)
+
+**Format**: Starts with "to be able to" or "to" + verb phrase
+
+This completes the sentence: "As a [user_type], I want [user_story_want]"
+
+**Good examples**:
+- "to be able to upload pins to my drafts without errors"
+- "to schedule posts for multiple accounts in one action"
+- "to understand how timezone settings affect my posting schedule"
+- "to reconnect my Pinterest account without losing scheduled pins"
+
+**Bad examples**:
+- "upload pins" (incomplete - missing "to be able to")
+- "the pins to work" (not first-person)
+- "fix the scheduling" (imperative, not infinitive)
+
+### 4. user_story_benefit (specific outcome)
+
+**Format**: Explains WHY the user wants this, specific to the problem.
+
+This completes: "So that [user_story_benefit]"
+
+**Good examples**:
+- "I can maintain my posting schedule without interruption"
+- "I save time on repetitive scheduling tasks"
+- "I can optimize my posting times for engagement"
+- "I don't miss my product launch deadlines"
+
+**Bad examples** (never use):
+- "I can achieve my goals" (too generic)
+- "achieve my goals without friction" (boilerplate)
+- "things work properly" (vague)
+
+### 5. ai_agent_goal (action + success criteria)
+
+**Format**: `[Action verb] the [specific issue]. Success: [measurable criteria]`
+
+Must include:
+- Specific action to take
+- Explicit "Success:" criteria (observable, measurable)
+
+**Good examples**:
+- "Resolve the pin upload failure where users receive Server 0 response code. Success: uploads complete successfully and pins appear in drafts within 5 seconds."
+- "Implement bulk scheduling for Instagram Reels. Success: user can select multiple reels and schedule with one action."
+- "Update documentation for SmartSchedule timezone behavior. Success: help docs clearly explain how user timezone affects scheduled post times."
+
+**Bad examples**:
+- "Fix the bug" (not specific)
+- "Make it work" (no success criteria)
+- "Resolve the issue and restore expected functionality" (generic)
+
+## Response Format
+
+Respond with valid JSON only. No markdown code blocks, no explanations outside JSON.
+
+{{
+  "title": "string (max 80 chars, action verb first, no trailing period)",
+  "user_type": "string (specific persona, NOT 'Tailwind user')",
+  "user_story_want": "string (starts with 'to', first-person infinitive)",
+  "user_story_benefit": "string (specific outcome, NOT 'achieve my goals')",
+  "ai_agent_goal": "string (must include 'Success:' criteria)"
+}}
+
+## Quality Checklist (verify before responding)
+
+- [ ] Title starts with appropriate action verb for category
+- [ ] Title is under 80 characters
+- [ ] user_type is NOT "Tailwind user" or "user"
+- [ ] user_story_want starts with "to"
+- [ ] user_story_benefit is specific to this problem
+- [ ] ai_agent_goal contains "Success:" followed by measurable criteria
+'''
+
+
+@dataclass
+class StoryContentInput:
+    """Input data for story content generation."""
+
+    # From grouped conversations
+    user_intents: List[str]  # All user_intent values from conversations
+    symptoms: List[str]      # All symptoms (deduplicated)
+    issue_signature: str     # The theme signature
+
+    # Context
+    classification_category: str  # product_issue, feature_request, how_to_question, account_issue, billing_question
+    product_area: str
+    component: str
+
+    # Optional: Additional context
+    root_cause_hypothesis: Optional[str] = None
+    affected_flow: Optional[str] = None
+    excerpts: Optional[List[str]] = None  # Conversation excerpts for additional context
+
+
+def format_user_intents(user_intents: List[str]) -> str:
+    """
+    Format user intents for the prompt.
+
+    Args:
+        user_intents: List of user intent strings
+
+    Returns:
+        Formatted string for inclusion in prompt
+    """
+    if not user_intents:
+        return "- (No user intent data available)"
+
+    # Deduplicate and limit
+    unique_intents = list(dict.fromkeys(user_intents))[:5]
+    return "\n".join(f"- {intent}" for intent in unique_intents)
+
+
+def format_symptoms(symptoms: List[str]) -> str:
+    """
+    Format symptoms for the prompt.
+
+    Args:
+        symptoms: List of symptom strings
+
+    Returns:
+        Formatted string for inclusion in prompt
+    """
+    if not symptoms:
+        return "- (No symptom data available)"
+
+    # Deduplicate and limit
+    unique_symptoms = list(dict.fromkeys(symptoms))[:5]
+    return "\n".join(f"- {symptom}" for symptom in unique_symptoms)
+
+
+def format_optional_context(
+    root_cause_hypothesis: Optional[str] = None,
+    affected_flow: Optional[str] = None,
+    excerpts: Optional[List[str]] = None,
+) -> str:
+    """
+    Format optional context sections for the prompt.
+
+    Args:
+        root_cause_hypothesis: Technical hypothesis about root cause
+        affected_flow: The user journey/flow affected
+        excerpts: Conversation excerpts for additional context
+
+    Returns:
+        Formatted optional context string
+    """
+    sections = []
+
+    if root_cause_hypothesis:
+        sections.append(f"### Root Cause Hypothesis\n{root_cause_hypothesis}")
+
+    if affected_flow:
+        sections.append(f"### Affected User Flow\n{affected_flow}")
+
+    if excerpts:
+        # Truncate and limit excerpts
+        formatted_excerpts = []
+        for excerpt in excerpts[:3]:
+            truncated = excerpt[:200] + "..." if len(excerpt) > 200 else excerpt
+            formatted_excerpts.append(f'> "{truncated}"')
+        sections.append("### Sample Customer Messages\n" + "\n".join(formatted_excerpts))
+
+    return "\n\n".join(sections)
+
+
+def build_story_content_prompt(content_input: StoryContentInput) -> str:
+    """
+    Build the complete story content generation prompt.
+
+    Args:
+        content_input: StoryContentInput with all required fields
+
+    Returns:
+        Complete formatted prompt string ready for OpenAI API
+    """
+    # Format the user intents
+    user_intents_formatted = format_user_intents(content_input.user_intents)
+
+    # Format symptoms
+    symptoms_formatted = format_symptoms(content_input.symptoms)
+
+    # Format optional context
+    optional_context = format_optional_context(
+        root_cause_hypothesis=content_input.root_cause_hypothesis,
+        affected_flow=content_input.affected_flow,
+        excerpts=content_input.excerpts,
+    )
+
+    return STORY_CONTENT_PROMPT.format(
+        classification_category=content_input.classification_category,
+        product_area=content_input.product_area,
+        component=content_input.component,
+        issue_signature=content_input.issue_signature,
+        user_intents_formatted=user_intents_formatted,
+        symptoms_formatted=symptoms_formatted,
+        optional_context=optional_context,
+    )

--- a/src/story_tracking/services/story_content_generator.py
+++ b/src/story_tracking/services/story_content_generator.py
@@ -1,0 +1,446 @@
+"""
+Story Content Generator
+
+Generates synthesized story content from grouped conversation data using LLM.
+Produces outcome-focused titles, context-specific user stories, and AI agent goals.
+
+Owner: Marcus (Backend)
+Prompt: Kai (Prompt Engineering) - src/prompts/story_content.py
+Architecture: docs/architecture/story-content-generation.md
+"""
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from openai import (
+    OpenAI,
+    APIConnectionError,
+    APITimeoutError,
+    InternalServerError,
+    RateLimitError,
+)
+
+from src.prompts.story_content import (
+    StoryContentInput,
+    build_story_content_prompt,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Default timeout for LLM calls (seconds)
+DEFAULT_TIMEOUT = 30.0
+
+# Classification category mapping for unknown categories
+DEFAULT_CATEGORY = "product_issue"
+
+# Valid classification categories
+VALID_CATEGORIES = {
+    "product_issue",
+    "feature_request",
+    "how_to_question",
+    "account_issue",
+    "billing_question",
+}
+
+
+@dataclass
+class GeneratedStoryContent:
+    """
+    LLM-generated story content.
+
+    All fields are populated either from LLM generation or mechanical fallbacks.
+    """
+
+    title: str
+    """
+    Outcome-focused story title.
+
+    Format: Action verb + specific problem
+    Examples:
+      - "Fix pin upload failures when saving to drafts"
+      - "Add bulk scheduling for Instagram Reels"
+      - "Clarify SmartSchedule timezone settings"
+    """
+
+    user_type: str
+    """
+    The persona for "As a [user_type]" in user story.
+
+    Examples:
+      - "content creator managing multiple Pinterest accounts"
+      - "social media manager scheduling bulk content"
+    """
+
+    user_story_want: str
+    """
+    First-person infinitive clause for "I want..." in user story.
+
+    Format: "to be able to [action] [context] [without error/successfully]"
+    """
+
+    user_story_benefit: str
+    """
+    The benefit clause for "So that [benefit]" in user story.
+
+    Should be specific to the problem, not generic "achieve my goals".
+    """
+
+    ai_agent_goal: str
+    """
+    Actionable goal with success criteria for AI agent.
+
+    Format: "[Action verb] the [specific issue]. Success: [measurable criteria]"
+    """
+
+
+class StoryContentGenerator:
+    """
+    Generates synthesized story content from grouped conversation data.
+
+    Uses a single LLM call to produce:
+    - Outcome-focused title
+    - Context-specific user type
+    - User story "I want" clause
+    - Context-specific benefit
+    - AI agent goal with success criteria
+
+    Features:
+    - Retry with exponential backoff on transient failures
+    - Mechanical fallback per field after retries exhausted
+    - Edge case handling for empty inputs and unknown categories
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.3,
+        timeout: float = DEFAULT_TIMEOUT,
+    ):
+        """
+        Initialize story content generator.
+
+        Args:
+            model: OpenAI model to use for generation
+            temperature: LLM temperature (lower = more deterministic)
+            timeout: Timeout for LLM calls in seconds
+        """
+        self.model = model
+        self.temperature = temperature
+        self.timeout = timeout
+        self._client: Optional[OpenAI] = None
+
+    @property
+    def client(self) -> OpenAI:
+        """Lazy-initialize OpenAI client."""
+        if self._client is None:
+            self._client = OpenAI()
+        return self._client
+
+    def generate(
+        self,
+        content_input: StoryContentInput,
+        max_retries: int = 3,
+    ) -> GeneratedStoryContent:
+        """
+        Generate story content with retry logic.
+
+        Retries with exponential backoff on transient failures (rate limit, timeout,
+        server errors). Falls back to mechanical defaults after retries exhausted.
+
+        Args:
+            content_input: StoryContentInput with conversation data
+            max_retries: Maximum number of retry attempts (default: 3)
+
+        Returns:
+            GeneratedStoryContent with all 5 fields populated
+        """
+        # Validate and normalize input
+        normalized_input = self._normalize_input(content_input)
+
+        base_delay = 1.0  # seconds
+
+        for attempt in range(max_retries):
+            try:
+                return self._call_llm(normalized_input)
+            except (RateLimitError, APITimeoutError, InternalServerError, APIConnectionError) as e:
+                if attempt == max_retries - 1:
+                    logger.warning(
+                        f"LLM generation failed after {max_retries} attempts: {e}"
+                    )
+                    return self._mechanical_fallback(normalized_input)
+                delay = base_delay * (2 ** attempt)  # 1s, 2s, 4s
+                logger.info(
+                    f"Transient error on attempt {attempt + 1}, "
+                    f"retrying in {delay}s: {type(e).__name__}"
+                )
+                time.sleep(delay)
+            except Exception as e:
+                # Non-transient errors - don't retry
+                logger.warning(f"Non-transient LLM error: {e}. Using mechanical fallback.")
+                return self._mechanical_fallback(normalized_input)
+
+        # Should not reach here, but safety fallback
+        return self._mechanical_fallback(normalized_input)
+
+    def _normalize_input(self, content_input: StoryContentInput) -> StoryContentInput:
+        """
+        Normalize and validate input, handling edge cases.
+
+        Edge cases handled:
+        - Empty user_intents: use first symptom as pseudo-intent, else use signature
+        - Empty symptoms: allowed (generate from user_intents only)
+        - Both empty: use signature-based defaults, log warning
+        - Unknown classification: map to product_issue, log warning
+
+        Args:
+            content_input: Original input
+
+        Returns:
+            Normalized StoryContentInput
+        """
+        user_intents = list(content_input.user_intents) if content_input.user_intents else []
+        symptoms = list(content_input.symptoms) if content_input.symptoms else []
+        classification = content_input.classification_category
+
+        # Handle unknown classification category
+        if classification not in VALID_CATEGORIES:
+            logger.warning(
+                f"Unknown classification category '{classification}', "
+                f"mapping to '{DEFAULT_CATEGORY}'"
+            )
+            classification = DEFAULT_CATEGORY
+
+        # Handle empty user_intents
+        if not user_intents:
+            if symptoms:
+                # Use first symptom as pseudo-intent
+                pseudo_intent = symptoms[0]
+                logger.debug(
+                    f"Empty user_intents, using symptom as pseudo-intent (hash: {hash(pseudo_intent) & 0xFFFFFFFF:08x})"
+                )
+                user_intents = [pseudo_intent]
+            else:
+                # Both empty - use signature-based default
+                logger.warning(
+                    f"Both user_intents and symptoms are empty for signature "
+                    f"'{content_input.issue_signature}'. Using signature-based defaults."
+                )
+                user_intents = [self._humanize_signature(content_input.issue_signature)]
+
+        return StoryContentInput(
+            user_intents=user_intents,
+            symptoms=symptoms,
+            issue_signature=content_input.issue_signature,
+            classification_category=classification,
+            product_area=content_input.product_area or "Unknown",
+            component=content_input.component or "Unknown",
+            root_cause_hypothesis=content_input.root_cause_hypothesis,
+            affected_flow=content_input.affected_flow,
+            excerpts=content_input.excerpts,
+        )
+
+    def _call_llm(self, content_input: StoryContentInput) -> GeneratedStoryContent:
+        """
+        Make LLM call to generate story content.
+
+        Args:
+            content_input: Normalized StoryContentInput
+
+        Returns:
+            GeneratedStoryContent from LLM response
+
+        Raises:
+            Various OpenAI errors on transient failures
+            ValueError on invalid response
+        """
+        # Build prompt
+        prompt = build_story_content_prompt(content_input)
+
+        # Truncate if too long (stay under token limits)
+        max_prompt_chars = 12000  # ~4000 tokens with buffer
+        if len(prompt) > max_prompt_chars:
+            logger.debug(
+                f"Truncating prompt from {len(prompt)} to {max_prompt_chars} chars"
+            )
+            prompt = prompt[:max_prompt_chars]
+
+        # Call OpenAI
+        response = self.client.chat.completions.create(
+            model=self.model,
+            temperature=self.temperature,
+            timeout=self.timeout,
+            response_format={"type": "json_object"},
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a product manager generating story content. Respond only with valid JSON.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+        )
+
+        # Parse response - handle null content (R1 fix)
+        response_text = response.choices[0].message.content
+        if response_text is None:
+            raise ValueError("OpenAI returned empty content")
+        response_text = response_text.strip()
+        return self._parse_response(response_text, content_input)
+
+    def _parse_response(
+        self,
+        response_text: str,
+        content_input: StoryContentInput,
+    ) -> GeneratedStoryContent:
+        """
+        Parse LLM response into GeneratedStoryContent.
+
+        Handles partial JSON by using valid fields and mechanical fallback for missing.
+
+        Args:
+            response_text: Raw JSON response from LLM
+            content_input: Original input for fallback values
+
+        Returns:
+            GeneratedStoryContent with all fields populated
+
+        Raises:
+            ValueError if JSON is completely invalid
+        """
+        try:
+            # Handle potential markdown code blocks
+            if "```json" in response_text:
+                response_text = response_text.split("```json")[1].split("```")[0]
+            elif "```" in response_text:
+                response_text = response_text.split("```")[1].split("```")[0]
+
+            data = json.loads(response_text.strip())
+        except json.JSONDecodeError as e:
+            logger.warning(f"Failed to parse LLM response as JSON: {e}")
+            raise ValueError(f"Invalid JSON response: {e}")
+
+        # Build fallback for missing fields
+        fallback = self._mechanical_fallback(content_input)
+
+        # Extract fields with fallback for missing/invalid
+        title = self._extract_field(data, "title", fallback.title)
+        user_type = self._extract_field(data, "user_type", fallback.user_type)
+        user_story_want = self._extract_field(data, "user_story_want", fallback.user_story_want)
+        user_story_benefit = self._extract_field(data, "user_story_benefit", fallback.user_story_benefit)
+        ai_agent_goal = self._extract_field(data, "ai_agent_goal", fallback.ai_agent_goal)
+
+        # Validate title length (max 80 chars)
+        if len(title) > 80:
+            title = title[:77] + "..."
+
+        return GeneratedStoryContent(
+            title=title,
+            user_type=user_type,
+            user_story_want=user_story_want,
+            user_story_benefit=user_story_benefit,
+            ai_agent_goal=ai_agent_goal,
+        )
+
+    def _extract_field(
+        self,
+        data: dict,
+        field_name: str,
+        fallback_value: str,
+    ) -> str:
+        """
+        Extract a field from parsed JSON with fallback.
+
+        Args:
+            data: Parsed JSON dict
+            field_name: Field name to extract
+            fallback_value: Value to use if field missing or invalid
+
+        Returns:
+            Field value or fallback
+        """
+        value = data.get(field_name)
+        if value is None or not isinstance(value, str) or not value.strip():
+            return fallback_value
+        return value.strip()
+
+    def _mechanical_fallback(
+        self,
+        content_input: StoryContentInput,
+    ) -> GeneratedStoryContent:
+        """
+        Generate purely mechanical fallback - no LLM involved.
+
+        Fallback logic per field:
+        - title: user_intent if > 10 chars, else humanize signature
+        - user_type: "Tailwind user"
+        - user_story_want: user_intent directly
+        - user_story_benefit: "achieve my goals without friction"
+        - ai_agent_goal: user_intent + success criteria
+
+        Args:
+            content_input: Normalized StoryContentInput
+
+        Returns:
+            GeneratedStoryContent with mechanical defaults
+        """
+        # M5: Log when fallback is used for debugging
+        logger.info(
+            f"Using mechanical fallback for signature (hash: {hash(content_input.issue_signature) & 0xFFFFFFFF:08x}) "
+            f"(category: {content_input.classification_category})"
+        )
+
+        # Get first user intent (or None)
+        user_intent = (
+            content_input.user_intents[0]
+            if content_input.user_intents
+            else None
+        )
+        signature = content_input.issue_signature
+
+        # Title: user_intent if > 10 chars, else humanize signature
+        if user_intent and len(user_intent) > 10:
+            title = user_intent
+        else:
+            title = self._humanize_signature(signature)
+
+        # Ensure title is under 80 chars
+        if len(title) > 80:
+            title = title[:77] + "..."
+
+        # user_story_want: use user_intent directly
+        want = user_intent if user_intent else "use the product successfully"
+
+        # ai_agent_goal: combine user_intent with success criteria (Q3 fix)
+        intent_prefix = user_intent or signature
+        ai_goal = f"{intent_prefix}. Success: issue is resolved and functionality works as expected."
+
+        # NOTE: These values intentionally match the "Bad examples" in story_content.py
+        # (M6/R6 documentation). This signals that LLM generation failed and content
+        # may need human review. Do not "fix" these to be more specific - they serve
+        # as fallback markers indicating mechanical generation was used.
+        return GeneratedStoryContent(
+            title=title,
+            user_type="Tailwind user",
+            user_story_want=want,
+            user_story_benefit="achieve my goals without friction",
+            ai_agent_goal=ai_goal,
+        )
+
+    def _humanize_signature(self, signature: str) -> str:
+        """
+        Convert issue_signature to human-readable title.
+
+        Examples:
+          - "pin_upload_failure" -> "Pin Upload Failure"
+          - "scheduling_error" -> "Scheduling Error"
+
+        Args:
+            signature: The issue_signature string
+
+        Returns:
+            Human-readable title
+        """
+        return signature.replace("_", " ").title()

--- a/tests/story_tracking/test_story_content_generator.py
+++ b/tests/story_tracking/test_story_content_generator.py
@@ -1,0 +1,971 @@
+"""
+Story Content Generator Tests
+
+Tests for StoryContentGenerator - LLM-generated story content from grouped conversation data.
+Run with: pytest tests/story_tracking/test_story_content_generator.py -v
+
+Architecture: docs/architecture/story-content-generation.md
+"""
+
+import json
+import pytest
+import time
+from unittest.mock import Mock, MagicMock, patch, PropertyMock
+
+import sys
+from pathlib import Path
+
+# Navigate up from tests/story_tracking/ to project root
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from openai import RateLimitError, APITimeoutError, APIConnectionError, InternalServerError
+
+from src.story_tracking.services.story_content_generator import (
+    StoryContentGenerator,
+    GeneratedStoryContent,
+    VALID_CATEGORIES,
+    DEFAULT_CATEGORY,
+)
+from src.prompts.story_content import StoryContentInput
+
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def generator():
+    """Create a StoryContentGenerator instance."""
+    return StoryContentGenerator(model="gpt-4o-mini", temperature=0.3)
+
+
+@pytest.fixture
+def sample_input():
+    """Create a sample StoryContentInput for testing."""
+    return StoryContentInput(
+        user_intents=[
+            "The user was trying to upload pins to their drafts",
+            "The user wanted to schedule pins for later",
+        ],
+        symptoms=["Server 0 response code", "pins not appearing in drafts"],
+        issue_signature="pinterest_pin_upload_failure",
+        classification_category="product_issue",
+        product_area="publishing",
+        component="pinterest",
+        root_cause_hypothesis="Server timeout during upload",
+        affected_flow="Pin scheduling flow",
+    )
+
+
+@pytest.fixture
+def feature_request_input():
+    """Create a sample StoryContentInput for feature_request."""
+    return StoryContentInput(
+        user_intents=["The user wants to schedule multiple Reels at once"],
+        symptoms=["No bulk scheduling option available"],
+        issue_signature="instagram_bulk_scheduling",
+        classification_category="feature_request",
+        product_area="publishing",
+        component="instagram",
+    )
+
+
+@pytest.fixture
+def how_to_question_input():
+    """Create a sample StoryContentInput for how_to_question."""
+    return StoryContentInput(
+        user_intents=["The user is confused about SmartSchedule timezone settings"],
+        symptoms=["Posts publishing at wrong times"],
+        issue_signature="smartschedule_timezone_confusion",
+        classification_category="how_to_question",
+        product_area="scheduling",
+        component="smartschedule",
+    )
+
+
+@pytest.fixture
+def account_issue_input():
+    """Create a sample StoryContentInput for account_issue."""
+    return StoryContentInput(
+        user_intents=["The user cannot connect their Pinterest account"],
+        symptoms=["OAuth connection timeout", "connection keeps failing"],
+        issue_signature="pinterest_oauth_failure",
+        classification_category="account_issue",
+        product_area="accounts",
+        component="pinterest",
+    )
+
+
+@pytest.fixture
+def billing_question_input():
+    """Create a sample StoryContentInput for billing_question."""
+    return StoryContentInput(
+        user_intents=["The user wants to understand their billing cycle"],
+        symptoms=["Confused about charge date"],
+        issue_signature="billing_cycle_confusion",
+        classification_category="billing_question",
+        product_area="billing",
+        component="subscriptions",
+    )
+
+
+@pytest.fixture
+def mock_openai_response():
+    """Create a mock OpenAI response with valid JSON content."""
+    return json.dumps({
+        "title": "Fix pin upload failures when saving to drafts",
+        "user_type": "content creator managing Pinterest accounts",
+        "user_story_want": "to be able to upload pins to my drafts without errors",
+        "user_story_benefit": "I can maintain my posting schedule without interruption",
+        "ai_agent_goal": "Resolve the pin upload failure where users receive Server 0 response code. Success: uploads complete successfully and pins appear in drafts within 5 seconds.",
+    })
+
+
+# -----------------------------------------------------------------------------
+# Unit Tests - Initialization
+# -----------------------------------------------------------------------------
+
+
+class TestStoryContentGeneratorInit:
+    """Test StoryContentGenerator initialization."""
+
+    def test_default_initialization(self):
+        """Test service initializes with default values."""
+        generator = StoryContentGenerator()
+        assert generator.model == "gpt-4o-mini"
+        assert generator.temperature == 0.3
+        assert generator.timeout == 30.0
+        assert generator._client is None  # Lazy initialization
+
+    def test_custom_initialization(self):
+        """Test service initializes with custom values."""
+        generator = StoryContentGenerator(
+            model="gpt-4",
+            temperature=0.5,
+            timeout=60.0,
+        )
+        assert generator.model == "gpt-4"
+        assert generator.temperature == 0.5
+        assert generator.timeout == 60.0
+
+    def test_lazy_client_initialization(self):
+        """Test that OpenAI client is lazily initialized."""
+        generator = StoryContentGenerator()
+        assert generator._client is None
+
+        # Access the client property
+        with patch("src.story_tracking.services.story_content_generator.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client = generator.client
+            assert client is not None
+            mock_openai.assert_called_once()
+
+
+# -----------------------------------------------------------------------------
+# Unit Tests - Basic Generation
+# -----------------------------------------------------------------------------
+
+
+class TestBasicGeneration:
+    """Test basic content generation functionality."""
+
+    def test_valid_input_produces_all_five_fields(self, generator, sample_input, mock_openai_response):
+        """Test that valid input produces all 5 fields."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = mock_openai_response
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        generator._client = mock_client
+
+        result = generator.generate(sample_input)
+
+        assert isinstance(result, GeneratedStoryContent)
+        assert result.title == "Fix pin upload failures when saving to drafts"
+        assert result.user_type == "content creator managing Pinterest accounts"
+        assert result.user_story_want == "to be able to upload pins to my drafts without errors"
+        assert result.user_story_benefit == "I can maintain my posting schedule without interruption"
+        assert "Success:" in result.ai_agent_goal
+
+    def test_all_classification_categories_produce_output(self, generator):
+        """Test that all classification categories produce appropriate output."""
+        inputs = {
+            "product_issue": StoryContentInput(
+                user_intents=["Test intent"],
+                symptoms=["Test symptom"],
+                issue_signature="test_sig",
+                classification_category="product_issue",
+                product_area="test",
+                component="test",
+            ),
+            "feature_request": StoryContentInput(
+                user_intents=["Test intent"],
+                symptoms=["Test symptom"],
+                issue_signature="test_sig",
+                classification_category="feature_request",
+                product_area="test",
+                component="test",
+            ),
+            "how_to_question": StoryContentInput(
+                user_intents=["Test intent"],
+                symptoms=["Test symptom"],
+                issue_signature="test_sig",
+                classification_category="how_to_question",
+                product_area="test",
+                component="test",
+            ),
+            "account_issue": StoryContentInput(
+                user_intents=["Test intent"],
+                symptoms=["Test symptom"],
+                issue_signature="test_sig",
+                classification_category="account_issue",
+                product_area="test",
+                component="test",
+            ),
+            "billing_question": StoryContentInput(
+                user_intents=["Test intent"],
+                symptoms=["Test symptom"],
+                issue_signature="test_sig",
+                classification_category="billing_question",
+                product_area="test",
+                component="test",
+            ),
+        }
+
+        for category, input_data in inputs.items():
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = json.dumps({
+                "title": f"Test title for {category}",
+                "user_type": "test user type",
+                "user_story_want": "to test something",
+                "user_story_benefit": "testing works",
+                "ai_agent_goal": "Test goal. Success: test passes.",
+            })
+
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            generator._client = mock_client
+
+            result = generator.generate(input_data)
+
+            assert isinstance(result, GeneratedStoryContent)
+            assert result.title is not None
+            assert len(result.title) > 0
+
+
+# -----------------------------------------------------------------------------
+# Unit Tests - Retry Logic
+# -----------------------------------------------------------------------------
+
+
+class TestRetryLogic:
+    """Test retry behavior for transient failures."""
+
+    def test_rate_limit_error_triggers_retry(self, generator, sample_input, mock_openai_response):
+        """Test that RateLimitError triggers retry with backoff."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = mock_openai_response
+
+        mock_client = MagicMock()
+        # First call raises RateLimitError, second succeeds
+        mock_client.chat.completions.create.side_effect = [
+            RateLimitError(
+                message="Rate limit exceeded",
+                response=MagicMock(status_code=429),
+                body=None,
+            ),
+            mock_response,
+        ]
+        generator._client = mock_client
+
+        with patch("time.sleep") as mock_sleep:
+            result = generator.generate(sample_input)
+
+        assert result.title == "Fix pin upload failures when saving to drafts"
+        mock_sleep.assert_called_once_with(1.0)  # First retry delay
+        assert mock_client.chat.completions.create.call_count == 2
+
+    def test_api_timeout_error_triggers_retry(self, generator, sample_input, mock_openai_response):
+        """Test that APITimeoutError triggers retry with backoff."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = mock_openai_response
+
+        mock_client = MagicMock()
+        # First call raises APITimeoutError, second succeeds
+        mock_client.chat.completions.create.side_effect = [
+            APITimeoutError(request=MagicMock()),
+            mock_response,
+        ]
+        generator._client = mock_client
+
+        with patch("time.sleep") as mock_sleep:
+            result = generator.generate(sample_input)
+
+        assert result.title == "Fix pin upload failures when saving to drafts"
+        mock_sleep.assert_called_once_with(1.0)
+
+    def test_internal_server_error_triggers_retry(self, generator, sample_input, mock_openai_response):
+        """Test that InternalServerError triggers retry with backoff."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = mock_openai_response
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            InternalServerError(
+                message="Internal server error",
+                response=MagicMock(status_code=500),
+                body=None,
+            ),
+            mock_response,
+        ]
+        generator._client = mock_client
+
+        with patch("time.sleep"):
+            result = generator.generate(sample_input)
+
+        assert result.title == "Fix pin upload failures when saving to drafts"
+
+    def test_api_connection_error_triggers_retry(self, generator, sample_input, mock_openai_response):
+        """Test that APIConnectionError triggers retry with backoff."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = mock_openai_response
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            APIConnectionError(request=MagicMock()),
+            mock_response,
+        ]
+        generator._client = mock_client
+
+        with patch("time.sleep"):
+            result = generator.generate(sample_input)
+
+        assert result.title == "Fix pin upload failures when saving to drafts"
+
+    def test_exponential_backoff_delays(self, generator, sample_input, mock_openai_response):
+        """Test that retries use exponential backoff (1s, 2s, 4s)."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = mock_openai_response
+
+        mock_client = MagicMock()
+        # Fail twice, succeed on third attempt
+        mock_client.chat.completions.create.side_effect = [
+            RateLimitError(message="Rate limit", response=MagicMock(status_code=429), body=None),
+            RateLimitError(message="Rate limit", response=MagicMock(status_code=429), body=None),
+            mock_response,
+        ]
+        generator._client = mock_client
+
+        with patch("time.sleep") as mock_sleep:
+            result = generator.generate(sample_input)
+
+        assert result.title == "Fix pin upload failures when saving to drafts"
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(1.0)  # First retry
+        mock_sleep.assert_any_call(2.0)  # Second retry
+
+    def test_non_transient_error_no_retry(self, generator, sample_input):
+        """Test that non-transient errors fall back immediately without retry."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Invalid parameter")
+        generator._client = mock_client
+
+        with patch("time.sleep") as mock_sleep:
+            result = generator.generate(sample_input)
+
+        # Should fall back to mechanical defaults without retrying
+        mock_sleep.assert_not_called()
+        assert mock_client.chat.completions.create.call_count == 1
+        # Should get mechanical fallback
+        assert result.user_type == "Tailwind user"
+
+    def test_exhausted_retries_falls_back(self, generator, sample_input):
+        """Test that after 3 attempts, falls back to mechanical defaults."""
+        mock_client = MagicMock()
+        # All 3 attempts fail with transient error
+        mock_client.chat.completions.create.side_effect = [
+            RateLimitError(message="Rate limit", response=MagicMock(status_code=429), body=None),
+            RateLimitError(message="Rate limit", response=MagicMock(status_code=429), body=None),
+            RateLimitError(message="Rate limit", response=MagicMock(status_code=429), body=None),
+        ]
+        generator._client = mock_client
+
+        with patch("time.sleep"):
+            result = generator.generate(sample_input, max_retries=3)
+
+        assert mock_client.chat.completions.create.call_count == 3
+        # Should get mechanical fallback
+        assert result.user_type == "Tailwind user"
+        assert result.user_story_benefit == "achieve my goals without friction"
+
+
+# -----------------------------------------------------------------------------
+# Unit Tests - Mechanical Fallbacks
+# -----------------------------------------------------------------------------
+
+
+class TestMechanicalFallbacks:
+    """Test mechanical fallback logic for each field."""
+
+    def test_title_uses_user_intent_if_longer_than_10_chars(self, generator, sample_input):
+        """Test title fallback uses user_intent if > 10 chars."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Force fallback")
+        generator._client = mock_client
+
+        result = generator.generate(sample_input)
+
+        # First user_intent is > 10 chars
+        assert result.title == sample_input.user_intents[0]
+
+    def test_title_uses_humanized_signature_if_intent_short(self, generator):
+        """Test title fallback humanizes signature if user_intent is short."""
+        short_intent_input = StoryContentInput(
+            user_intents=["Help"],  # Only 4 chars
+            symptoms=["Test symptom"],
+            issue_signature="pin_upload_failure",
+            classification_category="product_issue",
+            product_area="test",
+            component="test",
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Force fallback")
+        generator._client = mock_client
+
+        result = generator.generate(short_intent_input)
+
+        assert result.title == "Pin Upload Failure"
+
+    def test_user_type_defaults_to_tailwind_user(self, generator, sample_input):
+        """Test user_type fallback is 'Tailwind user'."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Force fallback")
+        generator._client = mock_client
+
+        result = generator.generate(sample_input)
+
+        assert result.user_type == "Tailwind user"
+
+    def test_user_story_want_uses_user_intent(self, generator, sample_input):
+        """Test user_story_want fallback uses user_intent directly."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Force fallback")
+        generator._client = mock_client
+
+        result = generator.generate(sample_input)
+
+        assert result.user_story_want == sample_input.user_intents[0]
+
+    def test_user_story_benefit_defaults_to_boilerplate(self, generator, sample_input):
+        """Test user_story_benefit fallback is 'achieve my goals without friction'."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Force fallback")
+        generator._client = mock_client
+
+        result = generator.generate(sample_input)
+
+        assert result.user_story_benefit == "achieve my goals without friction"
+
+    def test_ai_agent_goal_uses_user_intent_plus_boilerplate(self, generator, sample_input):
+        """Test ai_agent_goal fallback combines user_intent with success criteria."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Force fallback")
+        generator._client = mock_client
+
+        result = generator.generate(sample_input)
+
+        assert sample_input.user_intents[0] in result.ai_agent_goal
+        # Q3 fix: Uses "Success:" format per prompt requirements
+        assert "Success: issue is resolved and functionality works as expected" in result.ai_agent_goal
+
+    def test_title_truncated_to_80_chars(self, generator):
+        """Test that titles longer than 80 chars are truncated."""
+        long_intent = "A" * 100
+        long_intent_input = StoryContentInput(
+            user_intents=[long_intent],
+            symptoms=["Test symptom"],
+            issue_signature="test_sig",
+            classification_category="product_issue",
+            product_area="test",
+            component="test",
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Force fallback")
+        generator._client = mock_client
+
+        result = generator.generate(long_intent_input)
+
+        assert len(result.title) == 80
+        assert result.title.endswith("...")
+
+
+# -----------------------------------------------------------------------------
+# Unit Tests - Edge Cases
+# -----------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test edge case handling."""
+
+    def test_empty_user_intents_uses_first_symptom(self, generator):
+        """Test that empty user_intents uses first symptom as pseudo-intent."""
+        empty_intents_input = StoryContentInput(
+            user_intents=[],
+            symptoms=["Server 0 response code", "pins not appearing"],
+            issue_signature="test_sig",
+            classification_category="product_issue",
+            product_area="test",
+            component="test",
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Force fallback")
+        generator._client = mock_client
+
+        result = generator.generate(empty_intents_input)
+
+        # Should use first symptom
+        assert result.user_story_want == "Server 0 response code"
+
+    def test_empty_symptoms_still_works(self, generator):
+        """Test that empty symptoms list still produces valid output."""
+        no_symptoms_input = StoryContentInput(
+            user_intents=["The user was trying to upload pins"],
+            symptoms=[],
+            issue_signature="test_sig",
+            classification_category="product_issue",
+            product_area="test",
+            component="test",
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Force fallback")
+        generator._client = mock_client
+
+        result = generator.generate(no_symptoms_input)
+
+        assert isinstance(result, GeneratedStoryContent)
+        assert result.title is not None
+
+    def test_both_empty_uses_signature_based_defaults(self, generator):
+        """Test that both empty user_intents and symptoms uses signature-based defaults."""
+        both_empty_input = StoryContentInput(
+            user_intents=[],
+            symptoms=[],
+            issue_signature="pinterest_pin_upload_failure",
+            classification_category="product_issue",
+            product_area="test",
+            component="test",
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Force fallback")
+        generator._client = mock_client
+
+        result = generator.generate(both_empty_input)
+
+        # Should use humanized signature
+        assert result.title == "Pinterest Pin Upload Failure"
+        assert "Pinterest Pin Upload Failure" in result.ai_agent_goal
+
+    def test_unknown_classification_mapped_to_product_issue(self, generator):
+        """Test that unknown classification category is mapped to product_issue."""
+        unknown_category_input = StoryContentInput(
+            user_intents=["Test intent"],
+            symptoms=["Test symptom"],
+            issue_signature="test_sig",
+            classification_category="unknown_category",
+            product_area="test",
+            component="test",
+        )
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps({
+            "title": "Fix test issue",
+            "user_type": "test user",
+            "user_story_want": "to test",
+            "user_story_benefit": "testing works",
+            "ai_agent_goal": "Test. Success: pass.",
+        })
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        generator._client = mock_client
+
+        # Should not raise, should work with normalized category
+        result = generator.generate(unknown_category_input)
+        assert isinstance(result, GeneratedStoryContent)
+
+    def test_invalid_json_from_llm_retries_then_fallback(self, generator, sample_input):
+        """Test that invalid JSON from LLM triggers retry then fallback."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "This is not valid JSON at all"
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        generator._client = mock_client
+
+        result = generator.generate(sample_input)
+
+        # Should fall back to mechanical defaults after invalid JSON
+        assert result.user_type == "Tailwind user"
+
+    def test_partial_json_uses_valid_fields_plus_fallback(self, generator, sample_input):
+        """Test that partial JSON uses valid fields with fallback for missing."""
+        partial_json = json.dumps({
+            "title": "This is a valid title",
+            "user_type": "content creator",
+            # Missing: user_story_want, user_story_benefit, ai_agent_goal
+        })
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = partial_json
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        generator._client = mock_client
+
+        result = generator.generate(sample_input)
+
+        # Should use LLM values for present fields
+        assert result.title == "This is a valid title"
+        assert result.user_type == "content creator"
+        # Should use fallback for missing fields
+        assert result.user_story_want == sample_input.user_intents[0]
+        assert result.user_story_benefit == "achieve my goals without friction"
+
+    def test_very_long_inputs_truncated(self, generator):
+        """Test that very long inputs are truncated before LLM call."""
+        # Create input with very long content
+        long_intent = "A" * 5000
+        long_symptom = "B" * 5000
+        long_input = StoryContentInput(
+            user_intents=[long_intent],
+            symptoms=[long_symptom],
+            issue_signature="test_sig",
+            classification_category="product_issue",
+            product_area="test",
+            component="test",
+        )
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps({
+            "title": "Test title",
+            "user_type": "test user",
+            "user_story_want": "to test",
+            "user_story_benefit": "testing works",
+            "ai_agent_goal": "Test. Success: pass.",
+        })
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        generator._client = mock_client
+
+        # Should not raise, should handle long content
+        result = generator.generate(long_input)
+        assert isinstance(result, GeneratedStoryContent)
+
+        # Verify the prompt was called (confirming truncation logic ran)
+        assert mock_client.chat.completions.create.called
+
+    def test_json_in_markdown_code_blocks(self, generator, sample_input):
+        """Test parsing of JSON wrapped in markdown code blocks."""
+        markdown_wrapped_json = """```json
+        {
+            "title": "Fix pin upload issue",
+            "user_type": "content creator",
+            "user_story_want": "to upload pins",
+            "user_story_benefit": "I can publish content",
+            "ai_agent_goal": "Resolve issue. Success: pins upload."
+        }
+        ```"""
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = markdown_wrapped_json
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        generator._client = mock_client
+
+        result = generator.generate(sample_input)
+
+        assert result.title == "Fix pin upload issue"
+
+    def test_json_in_plain_code_blocks(self, generator, sample_input):
+        """Test parsing of JSON wrapped in plain code blocks."""
+        plain_code_block_json = """```
+        {
+            "title": "Fix pin upload issue",
+            "user_type": "content creator",
+            "user_story_want": "to upload pins",
+            "user_story_benefit": "I can publish content",
+            "ai_agent_goal": "Resolve issue. Success: pins upload."
+        }
+        ```"""
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = plain_code_block_json
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        generator._client = mock_client
+
+        result = generator.generate(sample_input)
+
+        assert result.title == "Fix pin upload issue"
+
+    def test_empty_string_fields_use_fallback(self, generator, sample_input):
+        """Test that empty string fields in JSON use fallback values."""
+        json_with_empty_fields = json.dumps({
+            "title": "",  # Empty
+            "user_type": "   ",  # Whitespace only
+            "user_story_want": "to upload pins",
+            "user_story_benefit": None,  # Null
+            "ai_agent_goal": "Test. Success: pass.",
+        })
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json_with_empty_fields
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        generator._client = mock_client
+
+        result = generator.generate(sample_input)
+
+        # Empty/whitespace fields should use fallback
+        assert result.title == sample_input.user_intents[0]  # Fallback
+        assert result.user_type == "Tailwind user"  # Fallback
+        # Valid fields should be used
+        assert result.user_story_want == "to upload pins"
+        # Null field should use fallback
+        assert result.user_story_benefit == "achieve my goals without friction"
+
+
+# -----------------------------------------------------------------------------
+# Unit Tests - Input Normalization
+# -----------------------------------------------------------------------------
+
+
+class TestInputNormalization:
+    """Test input normalization logic."""
+
+    def test_none_user_intents_handled(self, generator):
+        """Test that None user_intents are handled gracefully."""
+        # Create input with a list that might be empty
+        input_with_none_intents = StoryContentInput(
+            user_intents=[],  # Empty list
+            symptoms=["Test symptom"],
+            issue_signature="test_sig",
+            classification_category="product_issue",
+            product_area="test",
+            component="test",
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Force fallback")
+        generator._client = mock_client
+
+        result = generator.generate(input_with_none_intents)
+        assert isinstance(result, GeneratedStoryContent)
+
+    def test_none_symptoms_handled(self, generator):
+        """Test that None symptoms are handled gracefully."""
+        input_with_none_symptoms = StoryContentInput(
+            user_intents=["Test intent"],
+            symptoms=[],  # Empty list
+            issue_signature="test_sig",
+            classification_category="product_issue",
+            product_area="test",
+            component="test",
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ValueError("Force fallback")
+        generator._client = mock_client
+
+        result = generator.generate(input_with_none_symptoms)
+        assert isinstance(result, GeneratedStoryContent)
+
+    def test_none_product_area_defaults_to_unknown(self, generator):
+        """Test that None product_area defaults to 'Unknown'."""
+        input_with_none_product_area = StoryContentInput(
+            user_intents=["Test intent"],
+            symptoms=["Test symptom"],
+            issue_signature="test_sig",
+            classification_category="product_issue",
+            product_area=None,  # None
+            component=None,  # None
+        )
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps({
+            "title": "Test",
+            "user_type": "test",
+            "user_story_want": "to test",
+            "user_story_benefit": "test",
+            "ai_agent_goal": "Test. Success: pass.",
+        })
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        generator._client = mock_client
+
+        # Should not raise
+        result = generator.generate(input_with_none_product_area)
+        assert isinstance(result, GeneratedStoryContent)
+
+
+# -----------------------------------------------------------------------------
+# Unit Tests - GeneratedStoryContent Dataclass
+# -----------------------------------------------------------------------------
+
+
+class TestGeneratedStoryContent:
+    """Test GeneratedStoryContent dataclass."""
+
+    def test_dataclass_fields(self):
+        """Test that dataclass has all expected fields."""
+        content = GeneratedStoryContent(
+            title="Test Title",
+            user_type="Test User",
+            user_story_want="to test",
+            user_story_benefit="testing works",
+            ai_agent_goal="Test. Success: pass.",
+        )
+
+        assert content.title == "Test Title"
+        assert content.user_type == "Test User"
+        assert content.user_story_want == "to test"
+        assert content.user_story_benefit == "testing works"
+        assert content.ai_agent_goal == "Test. Success: pass."
+
+
+# -----------------------------------------------------------------------------
+# Unit Tests - Valid Categories Constant
+# -----------------------------------------------------------------------------
+
+
+class TestValidCategories:
+    """Test VALID_CATEGORIES constant."""
+
+    def test_valid_categories_contains_expected_values(self):
+        """Test that VALID_CATEGORIES contains all expected categories."""
+        expected = {
+            "product_issue",
+            "feature_request",
+            "how_to_question",
+            "account_issue",
+            "billing_question",
+        }
+        assert VALID_CATEGORIES == expected
+
+    def test_default_category_is_product_issue(self):
+        """Test that DEFAULT_CATEGORY is product_issue."""
+        assert DEFAULT_CATEGORY == "product_issue"
+
+
+# -----------------------------------------------------------------------------
+# Unit Tests - Humanize Signature
+# -----------------------------------------------------------------------------
+
+
+class TestHumanizeSignature:
+    """Test _humanize_signature helper method."""
+
+    def test_underscores_replaced_with_spaces(self, generator):
+        """Test that underscores are replaced with spaces."""
+        result = generator._humanize_signature("pin_upload_failure")
+        assert result == "Pin Upload Failure"
+
+    def test_title_case_applied(self, generator):
+        """Test that title case is applied."""
+        result = generator._humanize_signature("scheduling_error")
+        assert result == "Scheduling Error"
+
+    def test_single_word(self, generator):
+        """Test single word signature."""
+        result = generator._humanize_signature("error")
+        assert result == "Error"
+
+
+# -----------------------------------------------------------------------------
+# Unit Tests - Title Length Validation
+# -----------------------------------------------------------------------------
+
+
+class TestTitleLengthValidation:
+    """Test that titles are properly validated for length."""
+
+    def test_llm_response_title_truncated_if_too_long(self, generator, sample_input):
+        """Test that LLM response title is truncated if > 80 chars."""
+        long_title = "A" * 100
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps({
+            "title": long_title,
+            "user_type": "test user",
+            "user_story_want": "to test",
+            "user_story_benefit": "testing works",
+            "ai_agent_goal": "Test. Success: pass.",
+        })
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        generator._client = mock_client
+
+        result = generator.generate(sample_input)
+
+        assert len(result.title) == 80
+        assert result.title.endswith("...")
+
+
+# -----------------------------------------------------------------------------
+# Integration Tests (with actual OpenAI - skip in CI)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="Requires OpenAI API key - run manually")
+class TestStoryContentGeneratorIntegration:
+    """Integration tests that call actual OpenAI API."""
+
+    def test_real_generation_product_issue(self, sample_input):
+        """Test real API call for product_issue."""
+        generator = StoryContentGenerator()
+        result = generator.generate(sample_input)
+
+        assert isinstance(result, GeneratedStoryContent)
+        assert len(result.title) > 0
+        assert len(result.title) <= 80
+        assert result.user_type != "Tailwind user"  # Should be specific
+        assert result.user_story_want.startswith("to")
+        assert "Success:" in result.ai_agent_goal
+
+    def test_real_generation_feature_request(self, feature_request_input):
+        """Test real API call for feature_request."""
+        generator = StoryContentGenerator()
+        result = generator.generate(feature_request_input)
+
+        assert isinstance(result, GeneratedStoryContent)
+        # Feature requests should use "Add" verb
+        assert result.title.startswith("Add") or "add" in result.title.lower()


### PR DESCRIPTION
## Summary

- Add LLM-based story content generation from grouped conversations
- Generate 5 fields: title, user_type, user_story_want, user_story_benefit, ai_agent_goal
- Retry with exponential backoff on transient LLM failures
- Mechanical fallback per field when LLM unavailable
- Classification-aware title verbs (Fix/Add/Clarify/Resolve)

## Test plan

- [x] 39 unit tests passing (2 integration tests skipped - require API key)
- [x] 3-round 5-personality code review CONVERGED
- [x] Functional test: Direct generator call produces correct context-specific output
- [x] Pipeline run completed (orphan path limitation documented)

## Files changed

| File | Change |
|------|--------|
| `src/prompts/story_content.py` | NEW - LLM prompt template |
| `src/story_tracking/services/story_content_generator.py` | NEW - Generator service |
| `src/story_tracking/services/story_creation_service.py` | Integration with story creation |
| `src/story_formatter.py` | Use generated content in dual format |
| `src/api/routers/pipeline.py` | Pass classification through pipeline |
| `tests/story_tracking/test_story_content_generator.py` | NEW - 39 unit tests |
| `docs/architecture/story-content-generation.md` | NEW - Architecture doc |

🤖 Generated with [Claude Code](https://claude.com/claude-code)