### PR TITLE
Enhance test tier system with integration marker and API key safety

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,11 @@ Note: Unmarked tests are auto-assigned to 'fast' tier. To add a new test:
 - No marker needed for fast (unit) tests
 - Add @pytest.mark.medium for API TestClient tests
 - Add @pytest.mark.slow for external API / pipeline tests
+- Tests marked @pytest.mark.integration (without tier) default to 'medium'
+
+API Key Safety:
+- Fast/medium tests force-set a fake OPENAI_API_KEY to prevent accidental API calls
+- Only slow tests (and full suite) preserve real API keys from environment
 """
 
 import os
@@ -40,19 +45,34 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 def pytest_collection_modifyitems(config, items):
     """
-    Automatically assign 'fast' marker to unmarked tests.
+    Automatically assign tier markers to unmarked tests.
 
     This ensures backward compatibility and makes the tier system opt-out
     rather than opt-in. Tests are fast by default unless explicitly marked
     as medium or slow.
+
+    Special case: Tests marked with @pytest.mark.integration (but no tier)
+    are assigned to 'medium' tier since integration tests are typically
+    heavier than pure unit tests.
     """
     for item in items:
         # Skip if already has a tier marker
-        if any(item.iter_markers(name=tier) for tier in ('fast', 'medium', 'slow')):
+        # Note: Using explicit list checks instead of any() for reliability
+        has_tier = (
+            list(item.iter_markers(name='fast')) or
+            list(item.iter_markers(name='medium')) or
+            list(item.iter_markers(name='slow'))
+        )
+        if has_tier:
             continue
 
         # Skip if test is marked as skip (don't assign tier to skipped tests)
-        if any(item.iter_markers(name='skip')):
+        if list(item.iter_markers(name='skip')):
+            continue
+
+        # Integration tests without a tier marker default to medium
+        if list(item.iter_markers(name='integration')):
+            item.add_marker(pytest.mark.medium)
             continue
 
         # Add 'fast' marker to unmarked tests
@@ -65,9 +85,32 @@ def pytest_collection_modifyitems(config, items):
 
 def pytest_configure(config):
     """Configure pytest with custom settings."""
-    # Ensure OPENAI_API_KEY has a test value to prevent import errors.
-    # Uses setdefault so real keys in environment are preserved (for slow tests).
-    os.environ.setdefault("OPENAI_API_KEY", "sk-test-fake-key-for-testing")
+    # Determine if we're running slow tests (which may need real API keys).
+    # Check marker expression to decide key handling strategy.
+    markexpr = getattr(config.option, 'markexpr', '') or ''
+
+    # Real API keys are ONLY allowed when slow tests are being run:
+    # 1. Running slow tests explicitly: -m slow
+    # 2. Running full suite: --override-ini="addopts=" (markexpr empty)
+    #
+    # All other cases force a fake key to prevent accidental API calls:
+    # - Default: -m "not slow and not medium" (fast only)
+    # - Pre-merge: -m "not slow" (fast + medium)
+    # - Medium only: -m medium
+    includes_slow_tests = (
+        not markexpr or  # Full suite (no marker filter)
+        (
+            'slow' in markexpr and
+            'not slow' not in markexpr  # Positively includes slow tests
+        )
+    )
+
+    if includes_slow_tests:
+        # For slow tests or full suite, preserve real keys if present
+        os.environ.setdefault("OPENAI_API_KEY", "sk-test-fake-key-for-testing")
+    else:
+        # Force-set fake key for fast/medium tests to guard against mock failures
+        os.environ["OPENAI_API_KEY"] = "sk-test-fake-key-for-testing"
 
 
 # =============================================================================

--- a/tests/test_tier_system.py
+++ b/tests/test_tier_system.py
@@ -37,8 +37,26 @@ class TestTierMarkerConfiguration:
         assert True
 
     @pytest.mark.integration
-    def test_integration_marker(self):
-        """Verify 'integration' marker can be combined with tiers."""
+    def test_integration_marker_defaults_to_medium(self):
+        """
+        Verify 'integration' marker without tier defaults to medium.
+
+        This test is marked only with @pytest.mark.integration (no tier).
+        Per PR feedback, it should auto-assign to 'medium' tier, not 'fast'.
+
+        This test should:
+        - NOT run with: pytest (default fast tier)
+        - Run with: pytest -m medium
+        - Run with: pytest -m "not slow" (pre-merge)
+        - Run with: pytest --override-ini="addopts=" (full suite)
+        """
+        assert True
+
+    @pytest.mark.integration
+    @pytest.mark.slow
+    def test_integration_with_explicit_tier(self):
+        """Verify explicit tier marker overrides integration default."""
+        # Marked with both integration and slow - should be slow, not medium
         assert True
 
     @pytest.mark.serial


### PR DESCRIPTION
## Summary
This PR improves the pytest tier system by adding automatic tier assignment for integration tests and implementing stricter API key safety controls to prevent accidental API calls during test runs.

## Key Changes

### Test Tier System Enhancement
- **Integration marker auto-assignment**: Tests marked with `@pytest.mark.integration` (without an explicit tier) now automatically default to the `medium` tier, since integration tests are typically heavier than pure unit tests
- **Updated documentation**: Added clarification in conftest.py docstring explaining the integration marker behavior and API key safety strategy
- **Improved marker detection**: Changed from `any()` to explicit list checks for more reliable tier marker detection

### API Key Safety
- **Stricter key handling**: Fast and medium tests now force-set a fake `OPENAI_API_KEY` to prevent accidental API calls, even if a real key exists in the environment
- **Selective preservation**: Real API keys from the environment are only preserved when:
  - Running slow tests explicitly (`-m slow`)
  - Running the full test suite (no marker filter)
- **Smart detection**: The `pytest_configure` hook now analyzes the marker expression to determine whether slow tests are included in the run

### Test Coverage
- Added `test_integration_marker_defaults_to_medium()` to verify integration markers without explicit tiers default to medium
- Added `test_integration_with_explicit_tier()` to verify explicit tier markers override the integration default
- Updated test documentation with expected behavior for different pytest invocations

## Implementation Details
- The API key safety logic checks both the presence of `slow` in the marker expression AND the absence of `not slow` to correctly identify when slow tests are being run
- Empty `markexpr` indicates a full suite run (no marker filtering), which preserves real keys
- The tier assignment logic now handles the special case of integration markers before defaulting unmarked tests to fast

https://claude.ai/code/session_01Lz6CMt5KQzYweia41x9x6b