### PR TITLE
feat(pipeline): Add streaming batch resume for Intercom backfill (#209)

### DIFF
--- a/src/classification_pipeline.py
+++ b/src/classification_pipeline.py
@@ -664,16 +664,18 @@ async def _run_streaming_batch_pipeline_async(
         current_cursor[0] = next_page_cursor
 
     # Stats (cumulative across batches AND across resume sessions)
-    # On resume, seed from checkpoint counts so totals are cumulative
+    # On resume, seed from checkpoint.counts so totals are cumulative
     # NOTE: filtered=0 always in streaming mode (schema parity with legacy path)
     if checkpoint and checkpoint.get("phase") == "classification":
-        # Seed from checkpoint for cumulative totals across resume
+        # Seed from checkpoint.counts for cumulative totals across resume
+        # Checkpoint structure: {"phase": "classification", "counts": {"fetched": N, "classified": N, "stored": N}, ...}
+        counts = checkpoint.get("counts", {})
         stats = {
-            "fetched": checkpoint.get("conversations_fetched", 0),
+            "fetched": counts.get("fetched", 0),
             "filtered": 0,
             "recovered": 0,
-            "classified": checkpoint.get("conversations_classified", 0),
-            "stored": checkpoint.get("conversations_stored", 0),
+            "classified": counts.get("classified", 0),
+            "stored": counts.get("stored", 0),
             "stage2_run": 0,
             "classification_changed": 0,
             "warnings": [],

--- a/tests/test_pipeline_checkpoint.py
+++ b/tests/test_pipeline_checkpoint.py
@@ -943,13 +943,15 @@ class TestStreamingBatchPipeline:
 
         mock_client.fetch_quality_conversations_async = mock_generator
 
-        # Checkpoint with prior counts
+        # Checkpoint with prior counts (matches real checkpoint structure)
         checkpoint = {
             "phase": "classification",
             "intercom_cursor": "some_cursor",
-            "conversations_fetched": 100,
-            "conversations_classified": 95,
-            "conversations_stored": 90,
+            "counts": {
+                "fetched": 100,
+                "classified": 95,
+                "stored": 90,
+            },
         }
 
         result = await _run_streaming_batch_pipeline_async(


### PR DESCRIPTION
## Summary

Transforms the classification pipeline from "fetch-all-then-classify-all" to streaming batch architecture where each batch is fetched→classified→stored→checkpointed before moving to the next. This is the last blocker from Issue #205 before attempting a full historical backfill.

**Key guarantees:**
- Max rework on crash = 1 batch (~50 conversations)
- Memory bounded to 1 batch at any time
- Cursor resume skips already-fetched pages

## Changes

- **Feature-flagged rollout**: `PIPELINE_STREAMING_BATCH=true` to enable
- **Configurable batch size**: `PIPELINE_STREAMING_BATCH_SIZE` (10-500, default 50)
- **New functions**:
  - `_run_streaming_batch_pipeline_async`: Main streaming loop with cursor tracking
  - `_process_streaming_batch`: Per-batch processing (detail fetch → recovery → classify → store)
  - `_accumulate_stats`: Stats accumulation helper

## Checkpoint Invariants

1. **Cursor = NEXT page** — cursor_callback receives next page's cursor
2. **Cursor saved AFTER storage** — never before, prevents data loss on crash
3. **Stop checks at batch boundaries** — not during classification
4. **GREATEST() ensures monotonic counters** — existing SQL in _save_checkpoint

## Test plan

- [x] 13 new unit tests added for streaming batch mode
- [x] Env var parsing with bounds validation
- [x] Cursor resume behavior verified
- [x] Checkpoint timing (only after storage) verified
- [x] Recovery evaluation order verified
- [x] 5-personality code review (2 rounds, converged)
- [ ] Manual test: Set `PIPELINE_STREAMING_BATCH=true`, run small backfill
- [ ] Manual test: Start backfill, stop mid-run, resume with `resume=true`

## Rollout Plan

1. Merge with flag off (default: `PIPELINE_STREAMING_BATCH=false`)
2. Test with small backfill (~100 conversations)
3. Test resume after interrupt
4. Enable for full historical backfill
5. Remove legacy path once validated

Closes #209

🤖 Generated with [Claude Code](https://claude.ai/code)