### PR TITLE
feat(discovery): Codebase Explorer agent (#217)

### DIFF
--- a/docs/plans/codebase-explorer-217-plan.md
+++ b/docs/plans/codebase-explorer-217-plan.md
@@ -1,0 +1,329 @@
+# Codebase Explorer Implementation Plan — Issue #217
+
+## Overview
+
+Implement a Codebase Explorer agent that reads recently-changed source files
+via git and discovers patterns (tech debt, architecture opportunities,
+recurring complexity) using the same two-pass LLM strategy as the Customer
+Voice Explorer (#215).
+
+**Branch**: `feature/217-codebase-explorer`
+**Estimated files created**: 5
+**Estimated files modified**: 1 (prompts.py — add constants)
+**Infrastructure changes**: None
+
+---
+
+## Design Decisions
+
+### D1: CoverageMetadata field naming
+
+The `CoverageMetadata` Pydantic model has required fields named
+`conversations_available`, `conversations_reviewed`, `conversations_skipped`.
+For a codebase explorer, files are the unit of analysis, not conversations.
+
+**Decision**: Populate the `conversations_*` fields with file counts (since
+they are the required fields and the model validates them), AND add extra
+fields `items_type: "files"` to document what the numbers represent. The
+model uses `extra="allow"` so this works without schema changes.
+
+**Rationale**: Changing the model would be a breaking change affecting the
+Customer Voice Explorer and all existing tests. The readiness doc explicitly
+says "items can be conversations, events, files, documents — the invariant
+is about accounting for scope." The extra `items_type` field makes the
+semantics clear to downstream consumers.
+
+### D2: Data source — git log + file read
+
+The `CodebaseReader` uses `subprocess` to call `git log` and `git diff-tree`
+for recently-changed files. File contents are read directly from disk.
+No external API dependencies.
+
+**Scope boundaries**:
+
+- Default: `src/` directory only (production code, not tests/docs/config)
+- Exclusions: `__pycache__/`, `.git/`, `node_modules/`, binary files, `*.pyc`
+- Time window: files changed in last 30 days (configurable)
+- Max files: 100 (configurable)
+- Max chars per file: 3000 (code is denser than conversations)
+
+### D3: Batching strategy — hybrid
+
+Unlike conversations (uniform items), code files vary in size and relevance.
+Batch by recency: most-recently-changed files first, in groups of ~10-15.
+This puts highest-signal files (active development) in early batches.
+
+### D4: Evidence pointers
+
+`source_type: SourceType.CODEBASE`
+`source_id`: file path relative to repo root (e.g., `src/api/main.py`)
+
+For line-specific findings, the LLM can include line references in the
+description, but `source_id` stays at file level for stability (line numbers
+shift across commits).
+
+### D5: Prompt design — actionable opportunities, not observations
+
+The prompts must focus on patterns that would lead to actionable work:
+tech debt with measurable impact, architecture bottlenecks, duplicated
+logic, missing abstractions that cause bugs. NOT just "this function
+is long" observations.
+
+Critical constraint carried forward: NO reference to existing pipeline
+taxonomy, theme vocabulary, or predefined categories.
+
+---
+
+## Files to Create
+
+### 1. `src/discovery/agents/codebase_data_access.py`
+
+Data access layer for the codebase explorer.
+
+```python
+@dataclass
+class CodebaseItem:
+    path: str               # Relative to repo root
+    content: str            # File content (truncated to max_chars)
+    item_type: str          # "source_file"
+    metadata: Dict[str, Any]  # commit_count, last_modified, line_count, authors
+
+class CodebaseReader:
+    def __init__(self, repo_root: str, days: int = 30)
+
+    def fetch_recently_changed(self, days=30, limit=None) -> List[CodebaseItem]
+        # git log --name-only to find files changed in time window
+        # Read file contents from disk
+        # Exclude: __pycache__, .git, node_modules, binary, *.pyc
+        # Default scope: src/ directory
+        # Ordered by: most recent commit first
+
+    def fetch_file(self, path: str) -> Optional[CodebaseItem]
+        # Single file read for requery support
+
+    def get_item_count(self, days=30) -> int
+        # Count of files changed in time window (for coverage)
+```
+
+**Key implementation notes**:
+
+- `subprocess.run(["git", "log", ...])` for git operations
+- `pathlib.Path` for file reading
+- Skip binary files via `.suffix` check or `git diff --numstat` (binary shows `-`)
+- Metadata from `git log --format="%H %an %ai" --follow` per file
+
+### 2. `src/discovery/agents/codebase_explorer.py`
+
+The explorer agent itself. Follows the Customer Voice Explorer structure exactly.
+
+```python
+@dataclass
+class CodebaseExplorerConfig:
+    time_window_days: int = 30
+    max_files: int = 100
+    batch_size: int = 10      # Smaller than conversations (code is denser)
+    model: str = "gpt-4o-mini"
+    temperature: float = 0.7
+    max_chars_per_file: int = 3000
+
+class CodebaseExplorer:
+    def __init__(self, reader: CodebaseReader, openai_client=None, config=None)
+
+    def explore(self) -> ExplorerResult
+        # 1. Fetch recently changed files from reader
+        # 2. Split into batches (default 10 per batch)
+        # 3. Per-batch LLM analysis (pattern recognition)
+        # 4. Synthesis pass (dedup, cross-reference)
+        # 5. Return ExplorerResult
+
+    def requery(self, request_text, previous_findings, file_paths=None) -> Dict
+        # Follow-up questions; fetches specific files if paths provided
+
+    def build_checkpoint_artifacts(self, result: ExplorerResult) -> Dict
+        # Transform to ExplorerCheckpoint schema
+        # agent_name: "codebase"
+        # source_type: SourceType.CODEBASE
+        # evidence_file_paths → source_id
+
+    # Internal:
+    def _analyze_batch(self, batch, batch_idx) -> tuple
+    def _synthesize(self, all_batch_findings, total_reviewed) -> tuple
+    def _format_file(self, item: CodebaseItem) -> str
+        # [path] lines=N commits=M last_modified=...
+        # <file content, truncated to budget>
+```
+
+**Reused from Customer Voice** (same pattern):
+
+- `ExplorerResult` dataclass (imported from customer_voice module)
+- `_map_confidence()` helper (extract to shared location or copy)
+- Error handling: per-batch try/except, synthesis fallback
+- Coverage invariant: reviewed + skipped == available
+- LLM calling: `response_format={"type": "json_object"}`
+
+**Different from Customer Voice**:
+
+- `_format_file()` instead of `_format_conversation()`
+- Evidence key in LLM output: `evidence_file_paths` instead of `evidence_conversation_ids`
+- `agent_name: "codebase"` in checkpoint
+- `source_type: SourceType.CODEBASE` in evidence pointers
+
+### 3. Prompt additions to `src/discovery/agents/prompts.py`
+
+Six new prompt constants:
+
+**CODEBASE_BATCH_ANALYSIS_SYSTEM**: "You are a senior engineer reviewing
+recently-changed source code for patterns — tech debt, architecture
+opportunities, recurring complexity, duplicated logic, error-prone patterns,
+missing abstractions. NOT classifying into predefined categories. Discovering
+patterns from scratch."
+
+**CODEBASE_BATCH_ANALYSIS_USER**: Template with `{batch_size}`,
+`{time_window_days}`, `{formatted_files}`. Returns JSON with `findings`
+list where each finding has `evidence_file_paths` (not conversation IDs).
+
+**CODEBASE_SYNTHESIS_SYSTEM / \_USER**: Same merge/dedup/reassess pattern
+as Customer Voice synthesis.
+
+**CODEBASE_REQUERY_SYSTEM / \_USER**: Follow-up questions about specific
+files or patterns.
+
+### 4. `tests/discovery/test_codebase_explorer.py`
+
+Unit tests (~25 tests). Mirrors `test_customer_voice.py` structure.
+
+```python
+# Helpers
+_make_codebase_item(**overrides) -> CodebaseItem
+_make_batch_response(findings=None) -> mock LLM response
+_make_synthesis_response(findings=None)
+_make_llm_response(content_dict)
+
+class MockCodebaseReader:
+    def __init__(self, items=None, count=None)
+    def fetch_recently_changed(self, days, limit=None)
+    def fetch_file(self, path)
+    def get_item_count(self, days)
+
+# Test classes
+class TestExplore:          # happy path, empty, multi-batch, token tracking
+class TestErrorHandling:    # batch failure, synthesis fallback, invalid JSON
+class TestCoverageInvariant:# reviewed + skipped == available
+class TestFormatFile:       # truncation, metadata, empty files
+class TestBuildCheckpoint:  # valid checkpoint, validates against model, empty findings
+class TestRequery:          # with/without file paths
+class TestConfidenceMapping:# reuse _map_confidence tests
+```
+
+### 5. `tests/discovery/test_codebase_explorer_integration.py`
+
+Integration tests (~5 tests). Mirrors `test_explorer_integration.py`.
+
+```python
+@pytest.mark.slow
+class TestCodebaseExplorerFullFlow:
+    test_codebase_checkpoint_advances_to_opportunity_framing()
+    test_checkpoint_events_in_conversation()
+    test_empty_findings_checkpoint_still_advances()
+
+@pytest.mark.slow
+class TestCodebaseRequeryFlow:
+    test_requery_through_conversation()
+
+@pytest.mark.slow
+class TestCodebaseTaxonomyGuard:
+    test_findings_dont_use_pipeline_categories()
+```
+
+---
+
+## File to Modify
+
+### `src/discovery/agents/prompts.py`
+
+Add 6 new constants (CODEBASE_BATCH_ANALYSIS_SYSTEM, \_USER,
+CODEBASE_SYNTHESIS_SYSTEM, \_USER, CODEBASE_REQUERY_SYSTEM, \_USER).
+No changes to existing constants.
+
+---
+
+## Shared Code Decision: `_map_confidence`
+
+The `_map_confidence()` function currently lives in `customer_voice.py`.
+The codebase explorer needs the same function.
+
+**Decision**: Copy the function into `codebase_explorer.py` as a module-level
+helper (same pattern as Customer Voice). This avoids creating a shared
+utility for two callers, which would be premature abstraction. If a third
+explorer needs it, extract then.
+
+Similarly, `ExplorerResult` is defined in `customer_voice.py`. Rather than
+creating a shared module prematurely, re-define it in `codebase_explorer.py`
+(identical dataclass). When the orchestrator (#225) exists, it can extract
+shared types if needed.
+
+---
+
+## Implementation Order
+
+1. **CodebaseReader + CodebaseItem** (`codebase_data_access.py`)
+   - Data access layer, git integration, file reading
+   - No LLM dependency — testable in isolation
+
+2. **Prompts** (add to `prompts.py`)
+   - 6 new constants, no changes to existing
+
+3. **CodebaseExplorer** (`codebase_explorer.py`)
+   - Explorer agent following Customer Voice pattern
+   - Depends on reader and prompts
+
+4. **Unit tests** (`test_codebase_explorer.py`)
+   - Mock reader + mock LLM client
+   - ~25 tests covering all paths
+
+5. **Integration tests** (`test_codebase_explorer_integration.py`)
+   - Full state machine flow with InMemoryStorage/Transport
+   - ~5 tests
+
+6. **Verification**
+   - `pytest tests/discovery/ -v` — all discovery tests pass
+   - `pytest -m "not slow"` — no regressions in fast suite
+
+---
+
+## Acceptance Criteria
+
+1. `CodebaseReader.fetch_recently_changed()` returns files changed in the
+   last N days, excluding test/config/binary files
+2. `CodebaseExplorer.explore()` produces an `ExplorerResult` with findings
+   and coverage metadata
+3. Coverage invariant holds: `reviewed + skipped == available`
+4. `build_checkpoint_artifacts()` produces output that validates against
+   `ExplorerCheckpoint` model
+5. Per-batch errors are caught and don't abort the run
+6. Synthesis failure falls back to raw batch findings
+7. Checkpoint submission advances state machine to OPPORTUNITY_FRAMING
+8. Taxonomy guard passes: no pipeline vocabulary in output
+9. All existing discovery tests continue to pass (258 tests)
+10. New tests: ~25 unit + ~5 integration = ~30 total
+
+---
+
+## Risks and Mitigations
+
+| Risk                                                      | Mitigation                                                                                                            |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `subprocess.run` for git could be slow on large repos     | Limit to `src/` scope, cap at 100 files                                                                               |
+| Binary file detection could miss edge cases               | Use `.suffix` allowlist (.py, .ts, .js, .tsx, .jsx, .json, .yaml, .yml, .md, .sql, .html, .css) rather than blocklist |
+| LLM produces shallow "this function is long" observations | Prompt explicitly demands actionable patterns with impact assessment                                                  |
+| File content too large for LLM context                    | 3000 char budget per file, batch size of 10                                                                           |
+
+---
+
+## Out of Scope
+
+- Multi-explorer orchestration (Issue #225)
+- Functional testing against real codebase (would need functional test plan)
+- Changes to CoverageMetadata model (defer to when 3+ explorers exist)
+- Git blame analysis (defer to iteration)
+- Hotspot detection beyond recency (defer to iteration)

--- a/src/discovery/agents/codebase_data_access.py
+++ b/src/discovery/agents/codebase_data_access.py
@@ -1,0 +1,272 @@
+"""Data access for the Codebase Explorer agent.
+
+Reads recently-changed source files via git log + disk read. Deliberately
+scoped to production code (src/ by default) and excludes tests, docs,
+config, and binary files.
+
+No external API dependencies — just git and the local filesystem.
+"""
+
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# File extensions we consider source code (allowlist approach)
+SOURCE_EXTENSIONS = frozenset({
+    ".py", ".ts", ".js", ".tsx", ".jsx",
+    ".json", ".yaml", ".yml",
+    ".md", ".sql", ".html", ".css",
+    ".sh", ".toml", ".cfg", ".ini",
+})
+
+# Directories to always exclude
+EXCLUDED_DIRS = frozenset({
+    "__pycache__", ".git", "node_modules", ".mypy_cache",
+    ".pytest_cache", ".tox", "dist", "build", ".eggs",
+    "venv", ".venv", "env",
+})
+
+
+@dataclass
+class CodebaseItem:
+    """A file as the codebase explorer sees it.
+
+    Raw file content plus git metadata. No classification,
+    no analysis — just what's on disk and what git knows.
+    """
+
+    path: str  # Relative to repo root
+    content: str  # File content (may be truncated by explorer)
+    item_type: str = "source_file"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    # metadata keys: line_count, commit_count, last_modified, authors
+
+
+class CodebaseReader:
+    """Reads recently-changed source files for explorer agents.
+
+    Uses git log to identify files changed within a time window,
+    then reads their contents from disk. Scoped to a configurable
+    set of directories (default: src/).
+    """
+
+    def __init__(
+        self,
+        repo_root: str,
+        scope_dirs: Optional[List[str]] = None,
+    ):
+        self.repo_root = Path(repo_root)
+        self.scope_dirs = scope_dirs or ["src/"]
+
+    def fetch_recently_changed(
+        self,
+        days: int = 30,
+        limit: Optional[int] = None,
+    ) -> List[CodebaseItem]:
+        """Fetch files changed in the last N days.
+
+        Returns CodebaseItems ordered by most recent commit first.
+        Excludes binary files, test files, and excluded directories.
+
+        Args:
+            days: How many days back to look.
+            limit: Max files to return. None = no limit.
+
+        Returns:
+            List of CodebaseItem with file content and git metadata.
+        """
+        changed_files = self._get_changed_files(days)
+
+        if not changed_files:
+            logger.info("No changed files found in last %d days", days)
+            return []
+
+        items = []
+        skipped = 0
+
+        for file_path in changed_files:
+            if limit is not None and len(items) >= limit:
+                break
+
+            full_path = self.repo_root / file_path
+
+            if not full_path.exists() or not full_path.is_file():
+                skipped += 1
+                continue
+
+            if not self._is_in_scope(file_path):
+                skipped += 1
+                continue
+
+            if not self._is_source_file(file_path):
+                skipped += 1
+                continue
+
+            try:
+                content = full_path.read_text(encoding="utf-8", errors="replace")
+            except (OSError, UnicodeDecodeError) as e:
+                logger.warning("Could not read %s: %s", file_path, e)
+                skipped += 1
+                continue
+
+            metadata = self._get_file_metadata(file_path, days)
+
+            items.append(CodebaseItem(
+                path=file_path,
+                content=content,
+                metadata=metadata,
+            ))
+
+        if skipped > 0:
+            logger.info(
+                "Skipped %d files (out of scope, binary, or unreadable)", skipped
+            )
+
+        return items
+
+    def fetch_file(self, path: str) -> Optional[CodebaseItem]:
+        """Fetch a single file by path (for requery support)."""
+        full_path = self.repo_root / path
+
+        if not full_path.exists() or not full_path.is_file():
+            return None
+
+        try:
+            content = full_path.read_text(encoding="utf-8", errors="replace")
+        except (OSError, UnicodeDecodeError) as e:
+            logger.warning("Could not read %s: %s", path, e)
+            return None
+
+        metadata = self._get_file_metadata(path, days=30)
+
+        return CodebaseItem(
+            path=path,
+            content=content,
+            metadata=metadata,
+        )
+
+    def get_item_count(self, days: int = 30) -> int:
+        """Count of source files changed in the time window.
+
+        Counts only in-scope source files (same filter as fetch).
+        """
+        changed_files = self._get_changed_files(days)
+        count = 0
+        for file_path in changed_files:
+            full_path = self.repo_root / file_path
+            if (
+                full_path.exists()
+                and full_path.is_file()
+                and self._is_in_scope(file_path)
+                and self._is_source_file(file_path)
+            ):
+                count += 1
+        return count
+
+    # ========================================================================
+    # Internal methods
+    # ========================================================================
+
+    def _get_changed_files(self, days: int) -> List[str]:
+        """Get list of files changed in git within the time window.
+
+        Returns file paths relative to repo root, ordered by most
+        recent commit first. Deduplicates (a file changed in 3 commits
+        appears once).
+        """
+        since_date = f"{days} days ago"
+
+        try:
+            result = subprocess.run(
+                [
+                    "git", "log",
+                    f"--since={since_date}",
+                    "--name-only",
+                    "--pretty=format:",
+                    "--diff-filter=ACMR",  # Added, Copied, Modified, Renamed
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(self.repo_root),
+                timeout=30,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+            logger.warning("git log failed: %s", e)
+            return []
+
+        if result.returncode != 0:
+            logger.warning("git log returned %d: %s", result.returncode, result.stderr)
+            return []
+
+        # Deduplicate while preserving order (most recent first)
+        seen = set()
+        files = []
+        for line in result.stdout.strip().split("\n"):
+            line = line.strip()
+            if line and line not in seen:
+                seen.add(line)
+                files.append(line)
+
+        return files
+
+    def _is_in_scope(self, file_path: str) -> bool:
+        """Check if file falls within configured scope directories."""
+        # Check excluded directories
+        parts = Path(file_path).parts
+        for part in parts:
+            if part in EXCLUDED_DIRS:
+                return False
+
+        # Check scope directories
+        return any(file_path.startswith(scope) for scope in self.scope_dirs)
+
+    def _is_source_file(self, file_path: str) -> bool:
+        """Check if file is a recognized source file type."""
+        suffix = Path(file_path).suffix.lower()
+        return suffix in SOURCE_EXTENSIONS
+
+    def _get_file_metadata(self, file_path: str, days: int) -> Dict[str, Any]:
+        """Get git metadata for a file: commit count, authors, last modified."""
+        metadata: Dict[str, Any] = {}
+
+        full_path = self.repo_root / file_path
+        if full_path.exists():
+            with open(full_path, errors="replace") as f:
+                metadata["line_count"] = sum(1 for _ in f)
+
+        try:
+            result = subprocess.run(
+                [
+                    "git", "log",
+                    f"--since={days} days ago",
+                    "--format=%an|%aI",
+                    "--", file_path,
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(self.repo_root),
+                timeout=10,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                lines = [l.strip() for l in result.stdout.strip().split("\n") if l.strip()]
+                metadata["commit_count"] = len(lines)
+                authors = set()
+                last_modified = None
+                for line in lines:
+                    parts = line.split("|", 1)
+                    if len(parts) == 2:
+                        authors.add(parts[0])
+                        if last_modified is None:
+                            last_modified = parts[1]
+                metadata["authors"] = sorted(authors)
+                if last_modified:
+                    metadata["last_modified"] = last_modified
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+        return metadata

--- a/src/discovery/agents/codebase_explorer.py
+++ b/src/discovery/agents/codebase_explorer.py
@@ -1,0 +1,406 @@
+"""Codebase Explorer agent for the Discovery Engine.
+
+Reads recently-changed source files via git and reasons openly about patterns —
+NOT through predefined categories, NOT using the existing theme vocabulary.
+The artifact contracts validate output structure, not the agent's cognitive process.
+
+Two-pass LLM strategy:
+  1. Per-batch analysis: open-ended pattern recognition (~10 files per batch)
+  2. Synthesis pass: dedup and cross-reference findings across batches
+
+Per Issue #217: Second Stage 0 explorer. Discovers tech debt, architecture
+opportunities, and recurring code patterns that the structured pipeline
+can't see (because it only looks at customer conversations).
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from dotenv import load_dotenv
+
+from src.discovery.agents.codebase_data_access import CodebaseItem, CodebaseReader
+from src.discovery.agents.prompts import (
+    CODEBASE_BATCH_ANALYSIS_SYSTEM,
+    CODEBASE_BATCH_ANALYSIS_USER,
+    CODEBASE_REQUERY_SYSTEM,
+    CODEBASE_REQUERY_USER,
+    CODEBASE_SYNTHESIS_SYSTEM,
+    CODEBASE_SYNTHESIS_USER,
+)
+from src.discovery.models.enums import ConfidenceLevel, SourceType
+
+env_path = Path(__file__).parent.parent.parent.parent / ".env"
+if env_path.exists():
+    load_dotenv(env_path)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CodebaseExplorerConfig:
+    """Configuration for the Codebase Explorer."""
+
+    time_window_days: int = 30
+    max_files: int = 100
+    batch_size: int = 10
+    model: str = "gpt-4o-mini"
+    temperature: float = 0.7
+    max_chars_per_file: int = 3000
+
+
+@dataclass
+class ExplorerResult:
+    """Result of an exploration run, before checkpoint formatting."""
+
+    findings: List[Dict[str, Any]] = field(default_factory=list)
+    coverage: Dict[str, Any] = field(default_factory=dict)
+    token_usage: Dict[str, int] = field(default_factory=lambda: {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+    })
+    batch_errors: List[str] = field(default_factory=list)
+
+
+class CodebaseExplorer:
+    """Explorer agent that discovers patterns in recently-changed source code.
+
+    Uses a two-pass LLM strategy: per-batch analysis followed by synthesis.
+    """
+
+    def __init__(
+        self,
+        reader: CodebaseReader,
+        openai_client=None,
+        config: Optional[CodebaseExplorerConfig] = None,
+    ):
+        self.reader = reader
+        self.config = config or CodebaseExplorerConfig()
+
+        if openai_client is not None:
+            self.client = openai_client
+        else:
+            from openai import OpenAI
+            self.client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+    def explore(self) -> ExplorerResult:
+        """Run the full exploration: fetch → batch analyze → synthesize.
+
+        Per-batch errors are caught and recorded (batch skipped, files
+        counted as skipped), so one LLM failure doesn't abort the whole run.
+
+        Returns an ExplorerResult with findings and coverage metadata.
+        """
+        files = self.reader.fetch_recently_changed(
+            days=self.config.time_window_days,
+            limit=self.config.max_files,
+        )
+
+        total_available = self.reader.get_item_count(
+            days=self.config.time_window_days,
+        )
+
+        if not files:
+            logger.info("No source files found for exploration")
+            return ExplorerResult(
+                coverage={
+                    "time_window_days": self.config.time_window_days,
+                    "conversations_available": total_available,
+                    "conversations_reviewed": 0,
+                    "conversations_skipped": total_available,
+                    "model": self.config.model,
+                    "findings_count": 0,
+                    "items_type": "files",
+                },
+            )
+
+        # Split into batches
+        batches = [
+            files[i : i + self.config.batch_size]
+            for i in range(0, len(files), self.config.batch_size)
+        ]
+
+        all_batch_findings: List[List[Dict[str, Any]]] = []
+        reviewed_count = 0
+        skipped_count = 0
+        total_usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        batch_errors = []
+
+        for batch_idx, batch in enumerate(batches):
+            try:
+                findings, usage = self._analyze_batch(batch, batch_idx)
+                all_batch_findings.append(findings)
+                reviewed_count += len(batch)
+                for key in total_usage:
+                    total_usage[key] += usage.get(key, 0)
+            except Exception as e:
+                logger.warning(
+                    "Batch %d failed (%d files skipped): %s",
+                    batch_idx, len(batch), e,
+                )
+                skipped_count += len(batch)
+                batch_errors.append(f"Batch {batch_idx}: {e}")
+
+        # Synthesis pass
+        if all_batch_findings:
+            try:
+                synthesized, synth_usage = self._synthesize(
+                    all_batch_findings, reviewed_count
+                )
+                for key in total_usage:
+                    total_usage[key] += synth_usage.get(key, 0)
+            except Exception as e:
+                logger.warning("Synthesis failed, using raw batch findings: %s", e)
+                batch_errors.append(f"Synthesis: {e}")
+                synthesized = [f for batch in all_batch_findings for f in batch]
+        else:
+            synthesized = []
+
+        # Account for files not fetched (available > fetched)
+        not_fetched = max(0, total_available - len(files))
+
+        return ExplorerResult(
+            findings=synthesized,
+            coverage={
+                "time_window_days": self.config.time_window_days,
+                "conversations_available": total_available,
+                "conversations_reviewed": reviewed_count,
+                "conversations_skipped": skipped_count + not_fetched,
+                "model": self.config.model,
+                "findings_count": len(synthesized),
+                "items_type": "files",
+            },
+            token_usage=total_usage,
+            batch_errors=batch_errors,
+        )
+
+    def requery(
+        self,
+        request_text: str,
+        previous_findings: List[Dict[str, Any]],
+        file_paths: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Handle an explorer:request event with a follow-up question.
+
+        Fetches relevant files if paths provided, then asks the LLM.
+        """
+        relevant_text = ""
+        if file_paths:
+            file_contents = []
+            for path in file_paths:
+                item = self.reader.fetch_file(path)
+                if item:
+                    file_contents.append(item)
+            if file_contents:
+                relevant_text = "\n\n".join(
+                    self._format_file(f) for f in file_contents
+                )
+
+        user_prompt = CODEBASE_REQUERY_USER.format(
+            previous_findings_json=json.dumps(previous_findings, indent=2),
+            request_text=request_text,
+            relevant_files=relevant_text or "(no specific files requested)",
+        )
+
+        response = self.client.chat.completions.create(
+            model=self.config.model,
+            messages=[
+                {"role": "system", "content": CODEBASE_REQUERY_SYSTEM},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=self.config.temperature,
+            response_format={"type": "json_object"},
+        )
+
+        return json.loads(response.choices[0].message.content)
+
+    def build_checkpoint_artifacts(
+        self, result: ExplorerResult
+    ) -> Dict[str, Any]:
+        """Convert ExplorerResult into a dict validated against ExplorerCheckpoint.
+
+        Transforms raw LLM findings into typed EvidencePointer + ExplorerFinding
+        structures. Evidence pointers reference file paths (not line offsets),
+        so refactoring doesn't break references.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        findings = []
+
+        for raw_finding in result.findings:
+            evidence = []
+            for file_path in raw_finding.get("evidence_file_paths", []):
+                evidence.append({
+                    "source_type": SourceType.CODEBASE.value,
+                    "source_id": file_path,
+                    "retrieved_at": now,
+                    "confidence": _map_confidence(
+                        raw_finding.get("confidence", "medium")
+                    ),
+                })
+
+            findings.append({
+                "pattern_name": raw_finding.get("pattern_name", "unnamed"),
+                "description": raw_finding.get("description", ""),
+                "evidence": evidence,
+                "confidence": _map_confidence(
+                    raw_finding.get("confidence", "medium")
+                ),
+                "severity_assessment": raw_finding.get(
+                    "severity_assessment", "unknown"
+                ),
+                "affected_users_estimate": raw_finding.get(
+                    "affected_users_estimate", "unknown"
+                ),
+            })
+
+        return {
+            "schema_version": 1,
+            "agent_name": "codebase",
+            "findings": findings,
+            "coverage": result.coverage,
+        }
+
+    # ========================================================================
+    # Internal methods
+    # ========================================================================
+
+    def _analyze_batch(
+        self,
+        batch: List[CodebaseItem],
+        batch_idx: int,
+    ) -> tuple:
+        """Send one batch to LLM, parse JSON response.
+
+        Returns (findings_list, usage_dict).
+        """
+        formatted = "\n\n---\n\n".join(
+            self._format_file(item) for item in batch
+        )
+
+        user_prompt = CODEBASE_BATCH_ANALYSIS_USER.format(
+            batch_size=len(batch),
+            time_window_days=self.config.time_window_days,
+            formatted_files=formatted,
+        )
+
+        response = self.client.chat.completions.create(
+            model=self.config.model,
+            messages=[
+                {"role": "system", "content": CODEBASE_BATCH_ANALYSIS_SYSTEM},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=self.config.temperature,
+            response_format={"type": "json_object"},
+        )
+
+        usage = {}
+        if response.usage:
+            usage = {
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+            }
+
+        raw = json.loads(response.choices[0].message.content)
+
+        # JSON schema pre-check: must have a findings list
+        if not isinstance(raw.get("findings"), list):
+            raise ValueError(
+                f"Batch {batch_idx}: LLM response missing 'findings' list"
+            )
+
+        return raw["findings"], usage
+
+    def _synthesize(
+        self,
+        all_batch_findings: List[List[Dict[str, Any]]],
+        total_reviewed: int,
+    ) -> tuple:
+        """Merge findings across batches via LLM.
+
+        Returns (synthesized_findings, usage_dict).
+        """
+        batch_data = []
+        for idx, findings in enumerate(all_batch_findings):
+            batch_data.append({
+                "batch_index": idx,
+                "findings": findings,
+            })
+
+        user_prompt = CODEBASE_SYNTHESIS_USER.format(
+            num_batches=len(all_batch_findings),
+            total_files=total_reviewed,
+            time_window_days=self.config.time_window_days,
+            batch_findings_json=json.dumps(batch_data, indent=2),
+        )
+
+        response = self.client.chat.completions.create(
+            model=self.config.model,
+            messages=[
+                {"role": "system", "content": CODEBASE_SYNTHESIS_SYSTEM},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=self.config.temperature,
+            response_format={"type": "json_object"},
+        )
+
+        usage = {}
+        if response.usage:
+            usage = {
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+            }
+
+        raw = json.loads(response.choices[0].message.content)
+
+        if not isinstance(raw.get("findings"), list):
+            raise ValueError("Synthesis response missing 'findings' list")
+
+        return raw["findings"], usage
+
+    def _format_file(self, item: CodebaseItem) -> str:
+        """Format a file for LLM input with metadata and truncation.
+
+        Metadata line is always present. File content is truncated
+        to max_chars_per_file budget.
+        """
+        budget = self.config.max_chars_per_file
+
+        # Metadata line
+        line_count = item.metadata.get("line_count", "?")
+        commit_count = item.metadata.get("commit_count", "?")
+        last_modified = item.metadata.get("last_modified", "unknown")
+        authors = item.metadata.get("authors", [])
+        authors_str = ", ".join(authors) if authors else "unknown"
+
+        meta = (
+            f"[{item.path}] lines={line_count} commits={commit_count}"
+            f" last_modified={last_modified} authors={authors_str}"
+        )
+
+        content = item.content
+        if not content.strip():
+            return f"{meta}\n(empty file)"
+
+        if len(content) > budget:
+            content = content[:budget] + "\n[... truncated ...]"
+
+        return f"{meta}\n{content}"
+
+
+def _map_confidence(raw) -> str:
+    """Map LLM confidence strings to ConfidenceLevel enum values."""
+    if not isinstance(raw, str):
+        return ConfidenceLevel.MEDIUM.value
+    mapping = {
+        "high": ConfidenceLevel.HIGH.value,
+        "medium": ConfidenceLevel.MEDIUM.value,
+        "low": ConfidenceLevel.LOW.value,
+    }
+    return mapping.get(raw.lower(), ConfidenceLevel.MEDIUM.value)

--- a/tests/discovery/test_codebase_explorer.py
+++ b/tests/discovery/test_codebase_explorer.py
@@ -1,0 +1,711 @@
+"""Tests for the Codebase Explorer agent.
+
+Covers: explore flow, requery, checkpoint building, error handling,
+batching, file formatting, truncation, partial batch failure,
+coverage invariant, and confidence mapping.
+
+Uses mock OpenAI client + mock CodebaseReader.
+"""
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.discovery.agents.codebase_explorer import (
+    CodebaseExplorer,
+    CodebaseExplorerConfig,
+    ExplorerResult,
+    _map_confidence,
+)
+from src.discovery.agents.codebase_data_access import CodebaseItem
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_codebase_item(**overrides) -> CodebaseItem:
+    """Create a test CodebaseItem."""
+    defaults = {
+        "path": "src/api/main.py",
+        "content": "from fastapi import FastAPI\n\napp = FastAPI()\n",
+        "item_type": "source_file",
+        "metadata": {
+            "line_count": 3,
+            "commit_count": 2,
+            "last_modified": "2026-02-01T10:00:00+00:00",
+            "authors": ["dev1"],
+        },
+    }
+    defaults.update(overrides)
+    return CodebaseItem(**defaults)
+
+
+def _make_batch_response(findings=None):
+    """Create a mock LLM response for batch analysis."""
+    if findings is None:
+        findings = [
+            {
+                "pattern_name": "inconsistent_error_handling",
+                "description": "Error handling varies across API endpoints",
+                "evidence_file_paths": ["src/api/main.py"],
+                "confidence": "high",
+                "severity_assessment": "moderate impact on reliability",
+                "affected_users_estimate": "~30% of codebase",
+            }
+        ]
+    return _make_llm_response({"findings": findings, "batch_notes": ""})
+
+
+def _make_synthesis_response(findings=None):
+    """Create a mock LLM response for synthesis."""
+    if findings is None:
+        findings = [
+            {
+                "pattern_name": "inconsistent_error_handling",
+                "description": "Synthesized: error handling varies across endpoints",
+                "evidence_file_paths": ["src/api/main.py", "src/api/routes.py"],
+                "confidence": "high",
+                "severity_assessment": "moderate",
+                "affected_users_estimate": "~30% of codebase",
+                "batch_sources": [0],
+            }
+        ]
+    return _make_llm_response(
+        {"findings": findings, "synthesis_notes": "merged findings"}
+    )
+
+
+def _make_llm_response(content_dict):
+    """Create a mock OpenAI ChatCompletion response."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps(content_dict)
+    mock_response.usage = MagicMock()
+    mock_response.usage.prompt_tokens = 100
+    mock_response.usage.completion_tokens = 50
+    mock_response.usage.total_tokens = 150
+    return mock_response
+
+
+class MockCodebaseReader:
+    """Mock CodebaseReader for testing."""
+
+    def __init__(self, items=None, count=None):
+        self._items = items or []
+        self._count = count if count is not None else len(self._items)
+        self._by_path = {item.path: item for item in self._items}
+
+    def fetch_recently_changed(self, days, limit=None):
+        result = self._items
+        if limit:
+            result = result[:limit]
+        return result
+
+    def fetch_file(self, path):
+        return self._by_path.get(path)
+
+    def get_item_count(self, days):
+        return self._count
+
+
+# ============================================================================
+# Explore flow tests
+# ============================================================================
+
+
+class TestExplore:
+    def test_basic_explore_returns_findings(self):
+        items = [_make_codebase_item(path=f"src/module_{i}.py") for i in range(3)]
+        reader = MockCodebaseReader(items=items, count=3)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            _make_batch_response(),
+            _make_synthesis_response(),
+        ]
+
+        explorer = CodebaseExplorer(
+            reader=reader,
+            openai_client=mock_client,
+            config=CodebaseExplorerConfig(batch_size=20),
+        )
+        result = explorer.explore()
+
+        assert len(result.findings) == 1
+        assert result.findings[0]["pattern_name"] == "inconsistent_error_handling"
+        assert result.coverage["conversations_reviewed"] == 3
+        assert result.coverage["items_type"] == "files"
+
+    def test_empty_files_returns_empty_result(self):
+        reader = MockCodebaseReader(items=[], count=0)
+        mock_client = MagicMock()
+
+        explorer = CodebaseExplorer(reader=reader, openai_client=mock_client)
+        result = explorer.explore()
+
+        assert result.findings == []
+        assert result.coverage["conversations_reviewed"] == 0
+        assert result.coverage["conversations_available"] == 0
+        mock_client.chat.completions.create.assert_not_called()
+
+    def test_multiple_batches(self):
+        items = [_make_codebase_item(path=f"src/mod_{i}.py") for i in range(5)]
+        reader = MockCodebaseReader(items=items, count=5)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            _make_batch_response(),
+            _make_batch_response(findings=[{
+                "pattern_name": "duplicated_logic",
+                "description": "Same validation in two places",
+                "evidence_file_paths": ["src/mod_3.py"],
+                "confidence": "medium",
+                "severity_assessment": "high",
+                "affected_users_estimate": "~10%",
+            }]),
+            _make_synthesis_response(),
+        ]
+
+        explorer = CodebaseExplorer(
+            reader=reader,
+            openai_client=mock_client,
+            config=CodebaseExplorerConfig(batch_size=3),
+        )
+        result = explorer.explore()
+
+        # 2 batch calls + 1 synthesis call = 3 total
+        assert mock_client.chat.completions.create.call_count == 3
+        assert result.coverage["conversations_reviewed"] == 5
+
+    def test_tracks_token_usage(self):
+        items = [_make_codebase_item()]
+        reader = MockCodebaseReader(items=items, count=1)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            _make_batch_response(),
+            _make_synthesis_response(),
+        ]
+
+        explorer = CodebaseExplorer(reader=reader, openai_client=mock_client)
+        result = explorer.explore()
+
+        # 2 LLM calls * 150 tokens each
+        assert result.token_usage["total_tokens"] == 300
+
+
+# ============================================================================
+# Partial failure / error handling
+# ============================================================================
+
+
+class TestErrorHandling:
+    def test_batch_failure_skips_and_continues(self):
+        items = [_make_codebase_item(path=f"src/mod_{i}.py") for i in range(6)]
+        reader = MockCodebaseReader(items=items, count=6)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            _make_batch_response(),      # batch 0 succeeds
+            Exception("LLM timeout"),    # batch 1 fails
+            _make_synthesis_response(),  # synthesis
+        ]
+
+        explorer = CodebaseExplorer(
+            reader=reader,
+            openai_client=mock_client,
+            config=CodebaseExplorerConfig(batch_size=3),
+        )
+        result = explorer.explore()
+
+        assert result.coverage["conversations_reviewed"] == 3
+        assert result.coverage["conversations_skipped"] == 3
+        assert len(result.batch_errors) == 1
+        assert "Batch 1" in result.batch_errors[0]
+
+    def test_synthesis_failure_falls_back_to_raw(self):
+        items = [_make_codebase_item()]
+        reader = MockCodebaseReader(items=items, count=1)
+
+        raw_finding = {
+            "pattern_name": "raw_finding",
+            "description": "from batch",
+            "evidence_file_paths": ["src/api/main.py"],
+            "confidence": "medium",
+            "severity_assessment": "low",
+            "affected_users_estimate": "few",
+        }
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            _make_batch_response(findings=[raw_finding]),
+            Exception("Synthesis failed"),
+        ]
+
+        explorer = CodebaseExplorer(reader=reader, openai_client=mock_client)
+        result = explorer.explore()
+
+        assert len(result.findings) == 1
+        assert result.findings[0]["pattern_name"] == "raw_finding"
+        assert "Synthesis" in result.batch_errors[0]
+
+    def test_invalid_batch_json_raises(self):
+        items = [_make_codebase_item()]
+        reader = MockCodebaseReader(items=items, count=1)
+
+        # Response without a findings list
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response(
+            {"patterns": "wrong key"}
+        )
+
+        explorer = CodebaseExplorer(reader=reader, openai_client=mock_client)
+        result = explorer.explore()
+
+        # Batch fails, 1 file skipped, synthesis not called
+        assert result.coverage["conversations_skipped"] >= 1
+        assert len(result.batch_errors) == 1
+
+
+# ============================================================================
+# Coverage invariant
+# ============================================================================
+
+
+class TestCoverageInvariant:
+    def test_reviewed_plus_skipped_equals_available(self):
+        """Coverage reconciliation: reviewed + skipped == available."""
+        items = [_make_codebase_item(path=f"src/mod_{i}.py") for i in range(5)]
+        reader = MockCodebaseReader(items=items, count=5)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            _make_batch_response(),
+            _make_synthesis_response(),
+        ]
+
+        explorer = CodebaseExplorer(reader=reader, openai_client=mock_client)
+        result = explorer.explore()
+
+        cov = result.coverage
+        assert cov["conversations_reviewed"] + cov["conversations_skipped"] == cov["conversations_available"]
+
+    def test_coverage_accounts_for_unfetched(self):
+        """When available > fetched (due to limit), unfetched go to skipped."""
+        items = [_make_codebase_item(path=f"src/mod_{i}.py") for i in range(3)]
+        reader = MockCodebaseReader(items=items, count=10)  # 10 available, 3 fetched
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            _make_batch_response(),
+            _make_synthesis_response(),
+        ]
+
+        explorer = CodebaseExplorer(
+            reader=reader,
+            openai_client=mock_client,
+            config=CodebaseExplorerConfig(max_files=3),
+        )
+        result = explorer.explore()
+
+        cov = result.coverage
+        assert cov["conversations_reviewed"] == 3
+        assert cov["conversations_skipped"] == 7  # 10 - 3
+        assert cov["conversations_reviewed"] + cov["conversations_skipped"] == cov["conversations_available"]
+
+    def test_no_files_fetched_but_available(self):
+        """When fetch returns empty but count > 0, all go to skipped."""
+        reader = MockCodebaseReader(items=[], count=15)
+        mock_client = MagicMock()
+
+        explorer = CodebaseExplorer(reader=reader, openai_client=mock_client)
+        result = explorer.explore()
+
+        cov = result.coverage
+        assert cov["conversations_available"] == 15
+        assert cov["conversations_reviewed"] == 0
+        assert cov["conversations_skipped"] == 15
+        assert cov["conversations_reviewed"] + cov["conversations_skipped"] == cov["conversations_available"]
+
+    def test_coverage_with_partial_batch_failure(self):
+        """Coverage invariant holds even when batches fail."""
+        items = [_make_codebase_item(path=f"src/mod_{i}.py") for i in range(4)]
+        reader = MockCodebaseReader(items=items, count=4)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            Exception("batch 0 failed"),  # batch 0 fails
+            _make_batch_response(),        # batch 1 succeeds
+            _make_synthesis_response(),    # synthesis
+        ]
+
+        explorer = CodebaseExplorer(
+            reader=reader,
+            openai_client=mock_client,
+            config=CodebaseExplorerConfig(batch_size=2),
+        )
+        result = explorer.explore()
+
+        cov = result.coverage
+        assert cov["conversations_reviewed"] + cov["conversations_skipped"] == cov["conversations_available"]
+
+
+# ============================================================================
+# File formatting and truncation
+# ============================================================================
+
+
+class TestFormatFile:
+    def test_short_file_not_truncated(self):
+        item = _make_codebase_item(
+            content="def hello():\n    return 'world'\n"
+        )
+        explorer = CodebaseExplorer(
+            reader=MockCodebaseReader(), openai_client=MagicMock()
+        )
+
+        formatted = explorer._format_file(item)
+
+        assert "src/api/main.py" in formatted
+        assert "hello" in formatted
+        assert "truncated" not in formatted
+
+    def test_long_file_truncated(self):
+        content = "x = 1\n" * 2000  # Very long file
+        item = _make_codebase_item(content=content)
+        explorer = CodebaseExplorer(
+            reader=MockCodebaseReader(),
+            openai_client=MagicMock(),
+            config=CodebaseExplorerConfig(max_chars_per_file=500),
+        )
+
+        formatted = explorer._format_file(item)
+
+        # Content portion should be capped near budget
+        assert "truncated" in formatted
+
+    def test_metadata_always_present(self):
+        item = _make_codebase_item()
+        explorer = CodebaseExplorer(
+            reader=MockCodebaseReader(), openai_client=MagicMock()
+        )
+
+        formatted = explorer._format_file(item)
+
+        assert "src/api/main.py" in formatted
+        assert "lines=3" in formatted
+        assert "commits=2" in formatted
+
+    def test_empty_file_handled(self):
+        item = _make_codebase_item(content="")
+        explorer = CodebaseExplorer(
+            reader=MockCodebaseReader(), openai_client=MagicMock()
+        )
+
+        formatted = explorer._format_file(item)
+
+        assert "empty file" in formatted
+
+    def test_whitespace_only_file_handled(self):
+        item = _make_codebase_item(content="   \n  \n  ")
+        explorer = CodebaseExplorer(
+            reader=MockCodebaseReader(), openai_client=MagicMock()
+        )
+
+        formatted = explorer._format_file(item)
+
+        assert "empty file" in formatted
+
+    def test_metadata_with_missing_fields(self):
+        item = _make_codebase_item(metadata={})
+        explorer = CodebaseExplorer(
+            reader=MockCodebaseReader(), openai_client=MagicMock()
+        )
+
+        formatted = explorer._format_file(item)
+
+        assert "lines=?" in formatted
+        assert "commits=?" in formatted
+        assert "authors=unknown" in formatted
+
+    def test_truncation_at_budget_boundary(self):
+        """Content is truncated at exactly max_chars_per_file."""
+        content = "a" * 100
+        item = _make_codebase_item(content=content)
+        explorer = CodebaseExplorer(
+            reader=MockCodebaseReader(),
+            openai_client=MagicMock(),
+            config=CodebaseExplorerConfig(max_chars_per_file=50),
+        )
+
+        formatted = explorer._format_file(item)
+
+        # Meta line + 50 chars of content + truncation marker
+        lines = formatted.split("\n", 1)
+        content_part = lines[1] if len(lines) > 1 else ""
+        # Content before truncation marker should be <= 50 chars
+        assert "truncated" in content_part
+
+
+# ============================================================================
+# Checkpoint building
+# ============================================================================
+
+
+class TestBuildCheckpoint:
+    def test_builds_valid_checkpoint(self):
+        result = ExplorerResult(
+            findings=[
+                {
+                    "pattern_name": "test_pattern",
+                    "description": "A test",
+                    "evidence_file_paths": ["src/api/main.py"],
+                    "confidence": "high",
+                    "severity_assessment": "moderate",
+                    "affected_users_estimate": "~10%",
+                }
+            ],
+            coverage={
+                "time_window_days": 30,
+                "conversations_available": 100,
+                "conversations_reviewed": 95,
+                "conversations_skipped": 5,
+                "model": "gpt-4o-mini",
+                "findings_count": 1,
+                "items_type": "files",
+            },
+        )
+
+        explorer = CodebaseExplorer(
+            reader=MockCodebaseReader(), openai_client=MagicMock()
+        )
+        checkpoint = explorer.build_checkpoint_artifacts(result)
+
+        assert checkpoint["schema_version"] == 1
+        assert checkpoint["agent_name"] == "codebase"
+        assert len(checkpoint["findings"]) == 1
+        assert checkpoint["findings"][0]["pattern_name"] == "test_pattern"
+        assert len(checkpoint["findings"][0]["evidence"]) == 1
+        assert checkpoint["findings"][0]["evidence"][0]["source_type"] == "codebase"
+        assert checkpoint["coverage"]["conversations_reviewed"] == 95
+
+    def test_checkpoint_validates_against_model(self):
+        """Checkpoint output should pass ExplorerCheckpoint validation."""
+        from src.discovery.models.artifacts import ExplorerCheckpoint
+
+        result = ExplorerResult(
+            findings=[
+                {
+                    "pattern_name": "validated_pattern",
+                    "description": "Should validate",
+                    "evidence_file_paths": ["src/api/main.py"],
+                    "confidence": "high",
+                    "severity_assessment": "low",
+                    "affected_users_estimate": "few",
+                }
+            ],
+            coverage={
+                "time_window_days": 30,
+                "conversations_available": 50,
+                "conversations_reviewed": 50,
+                "conversations_skipped": 0,
+                "model": "gpt-4o-mini",
+                "findings_count": 1,
+                "items_type": "files",
+            },
+        )
+
+        explorer = CodebaseExplorer(
+            reader=MockCodebaseReader(), openai_client=MagicMock()
+        )
+        checkpoint = explorer.build_checkpoint_artifacts(result)
+
+        # Should not raise
+        validated = ExplorerCheckpoint(**checkpoint)
+        assert validated.agent_name == "codebase"
+        assert len(validated.findings) == 1
+
+    def test_empty_findings_checkpoint(self):
+        result = ExplorerResult(
+            findings=[],
+            coverage={
+                "time_window_days": 30,
+                "conversations_available": 10,
+                "conversations_reviewed": 10,
+                "conversations_skipped": 0,
+                "model": "gpt-4o-mini",
+                "findings_count": 0,
+                "items_type": "files",
+            },
+        )
+
+        explorer = CodebaseExplorer(
+            reader=MockCodebaseReader(), openai_client=MagicMock()
+        )
+        checkpoint = explorer.build_checkpoint_artifacts(result)
+
+        assert checkpoint["findings"] == []
+        assert checkpoint["coverage"]["findings_count"] == 0
+
+    def test_checkpoint_evidence_uses_codebase_source_type(self):
+        result = ExplorerResult(
+            findings=[
+                {
+                    "pattern_name": "some_pattern",
+                    "description": "desc",
+                    "evidence_file_paths": ["src/foo.py", "src/bar.py"],
+                    "confidence": "medium",
+                    "severity_assessment": "low",
+                    "affected_users_estimate": "few",
+                }
+            ],
+            coverage={
+                "time_window_days": 30,
+                "conversations_available": 5,
+                "conversations_reviewed": 5,
+                "conversations_skipped": 0,
+                "model": "gpt-4o-mini",
+                "findings_count": 1,
+                "items_type": "files",
+            },
+        )
+
+        explorer = CodebaseExplorer(
+            reader=MockCodebaseReader(), openai_client=MagicMock()
+        )
+        checkpoint = explorer.build_checkpoint_artifacts(result)
+
+        for evidence in checkpoint["findings"][0]["evidence"]:
+            assert evidence["source_type"] == "codebase"
+
+    def test_finding_without_evidence_paths(self):
+        """Finding with no evidence_file_paths should produce empty evidence."""
+        result = ExplorerResult(
+            findings=[
+                {
+                    "pattern_name": "no_evidence_pattern",
+                    "description": "pattern without file paths",
+                    "confidence": "low",
+                    "severity_assessment": "low",
+                    "affected_users_estimate": "unknown",
+                }
+            ],
+            coverage={
+                "time_window_days": 30,
+                "conversations_available": 5,
+                "conversations_reviewed": 5,
+                "conversations_skipped": 0,
+                "model": "gpt-4o-mini",
+                "findings_count": 1,
+                "items_type": "files",
+            },
+        )
+
+        explorer = CodebaseExplorer(
+            reader=MockCodebaseReader(), openai_client=MagicMock()
+        )
+        checkpoint = explorer.build_checkpoint_artifacts(result)
+
+        assert checkpoint["findings"][0]["evidence"] == []
+
+
+# ============================================================================
+# Requery
+# ============================================================================
+
+
+class TestRequery:
+    def test_requery_returns_answer(self):
+        items = [_make_codebase_item()]
+        reader = MockCodebaseReader(items=items)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response({
+            "answer": "The error handling pattern is inconsistent in 3 files",
+            "evidence_file_paths": ["src/api/main.py"],
+            "confidence": "high",
+            "additional_findings": [],
+        })
+
+        explorer = CodebaseExplorer(reader=reader, openai_client=mock_client)
+        result = explorer.requery(
+            request_text="How many files have inconsistent error handling?",
+            previous_findings=[],
+            file_paths=["src/api/main.py"],
+        )
+
+        assert result["answer"] == "The error handling pattern is inconsistent in 3 files"
+
+    def test_requery_without_file_paths(self):
+        reader = MockCodebaseReader()
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response({
+            "answer": "Based on previous findings...",
+            "evidence_file_paths": [],
+            "confidence": "medium",
+            "additional_findings": [],
+        })
+
+        explorer = CodebaseExplorer(reader=reader, openai_client=mock_client)
+        result = explorer.requery(
+            request_text="Summarize patterns",
+            previous_findings=[{"pattern_name": "test"}],
+        )
+
+        assert "Based on previous" in result["answer"]
+
+    def test_requery_with_missing_file(self):
+        """Requery for a file not in the reader should still work."""
+        reader = MockCodebaseReader(items=[])  # No files
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response({
+            "answer": "Could not access that file",
+            "evidence_file_paths": [],
+            "confidence": "low",
+            "additional_findings": [],
+        })
+
+        explorer = CodebaseExplorer(reader=reader, openai_client=mock_client)
+        result = explorer.requery(
+            request_text="What about src/missing.py?",
+            previous_findings=[],
+            file_paths=["src/missing.py"],
+        )
+
+        assert "Could not access" in result["answer"]
+
+
+# ============================================================================
+# Confidence mapping
+# ============================================================================
+
+
+class TestConfidenceMapping:
+    def test_maps_high(self):
+        assert _map_confidence("high") == "high"
+
+    def test_maps_medium(self):
+        assert _map_confidence("medium") == "medium"
+
+    def test_maps_low(self):
+        assert _map_confidence("low") == "low"
+
+    def test_unknown_defaults_to_medium(self):
+        assert _map_confidence("uncertain") == "medium"
+
+    def test_case_insensitive(self):
+        assert _map_confidence("HIGH") == "high"
+
+    def test_none_defaults_to_medium(self):
+        assert _map_confidence(None) == "medium"
+
+    def test_non_string_defaults_to_medium(self):
+        assert _map_confidence(42) == "medium"
+        assert _map_confidence({"level": "high"}) == "medium"

--- a/tests/discovery/test_codebase_explorer_integration.py
+++ b/tests/discovery/test_codebase_explorer_integration.py
@@ -1,0 +1,370 @@
+"""Integration tests for the Codebase Explorer with the state machine.
+
+Tests the full flow: create run → start → create EXPLORATION stage conversation
+→ codebase explorer produces findings → submit checkpoint (validated against
+ExplorerCheckpoint) → verify stage advances to OPPORTUNITY_FRAMING.
+
+Also tests requery flow and taxonomy guard.
+
+Marked @pytest.mark.slow for the test runner.
+Uses InMemoryTransport and InMemoryStorage (same as test_conversation_service.py).
+"""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.discovery.agents.codebase_explorer import (
+    CodebaseExplorer,
+    CodebaseExplorerConfig,
+    ExplorerResult,
+)
+from src.discovery.agents.codebase_data_access import CodebaseItem
+from src.discovery.models.artifacts import ExplorerCheckpoint
+from src.discovery.models.conversation import EventType
+from src.discovery.models.enums import (
+    RunStatus,
+    SourceType,
+    StageStatus,
+    StageType,
+)
+from src.discovery.models.run import DiscoveryRun, StageExecution
+from src.discovery.services.conversation import ConversationService
+from src.discovery.services.state_machine import DiscoveryStateMachine
+from src.discovery.services.transport import InMemoryTransport
+
+# Import directly to avoid duplication
+from tests.discovery.test_conversation_service import InMemoryStorage
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_codebase_item(**overrides) -> CodebaseItem:
+    defaults = {
+        "path": "src/api/main.py",
+        "content": "from fastapi import FastAPI\n\napp = FastAPI()\n",
+        "item_type": "source_file",
+        "metadata": {
+            "line_count": 3,
+            "commit_count": 2,
+            "last_modified": "2026-02-01T10:00:00+00:00",
+            "authors": ["dev1"],
+        },
+    }
+    defaults.update(overrides)
+    return CodebaseItem(**defaults)
+
+
+class MockCodebaseReader:
+    def __init__(self, items=None, count=None):
+        self._items = items or []
+        self._count = count if count is not None else len(self._items)
+        self._by_path = {item.path: item for item in self._items}
+
+    def fetch_recently_changed(self, days, limit=None):
+        result = self._items
+        if limit:
+            result = result[:limit]
+        return result
+
+    def fetch_file(self, path):
+        return self._by_path.get(path)
+
+    def get_item_count(self, days):
+        return self._count
+
+
+def _make_llm_response(content_dict):
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps(content_dict)
+    mock_response.usage = MagicMock()
+    mock_response.usage.prompt_tokens = 100
+    mock_response.usage.completion_tokens = 50
+    mock_response.usage.total_tokens = 150
+    return mock_response
+
+
+def _make_explorer_with_findings(findings=None):
+    """Create a CodebaseExplorer that will produce the given findings."""
+    if findings is None:
+        findings = [
+            {
+                "pattern_name": "inconsistent_error_handling",
+                "description": "Error handling varies across API endpoints",
+                "evidence_file_paths": ["src/api/main.py"],
+                "confidence": "high",
+                "severity_assessment": "moderate impact",
+                "affected_users_estimate": "~30% of codebase",
+            }
+        ]
+
+    items = [_make_codebase_item(path=f"src/mod_{i}.py") for i in range(3)]
+    reader = MockCodebaseReader(items=items, count=3)
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = [
+        _make_llm_response({"findings": findings, "batch_notes": ""}),
+        _make_llm_response({"findings": findings, "synthesis_notes": ""}),
+    ]
+
+    explorer = CodebaseExplorer(
+        reader=reader,
+        openai_client=mock_client,
+        config=CodebaseExplorerConfig(batch_size=20),
+    )
+    return explorer
+
+
+# ============================================================================
+# Full flow integration tests
+# ============================================================================
+
+
+@pytest.mark.slow
+class TestCodebaseExplorerFullFlow:
+    """Full flow: run → explore → checkpoint → advance."""
+
+    def test_codebase_checkpoint_advances_to_opportunity_framing(self):
+        """End-to-end: codebase explorer produces findings → checkpoint validates →
+        state machine advances to OPPORTUNITY_FRAMING."""
+        storage = InMemoryStorage()
+        transport = InMemoryTransport()
+        state_machine = DiscoveryStateMachine(storage=storage)
+        service = ConversationService(
+            transport=transport, storage=storage, state_machine=state_machine
+        )
+
+        # Create and start run
+        run = state_machine.create_run()
+        run = state_machine.start_run(run.id)
+        assert run.current_stage == StageType.EXPLORATION
+
+        # Create conversation for exploration stage
+        active = storage.get_active_stage(run.id)
+        convo_id = service.create_stage_conversation(run.id, active.id)
+
+        # Explorer produces findings
+        explorer = _make_explorer_with_findings()
+        result = explorer.explore()
+        checkpoint = explorer.build_checkpoint_artifacts(result)
+
+        # Validate checkpoint against model before submission
+        validated = ExplorerCheckpoint(**checkpoint)
+        assert validated.agent_name == "codebase"
+
+        # Submit checkpoint — this should advance the stage
+        new_stage = service.submit_checkpoint(
+            convo_id, run.id, "codebase", artifacts=checkpoint
+        )
+
+        assert new_stage.stage == StageType.OPPORTUNITY_FRAMING
+        assert new_stage.status == StageStatus.IN_PROGRESS
+
+        # Verify old stage is completed
+        old_stages = storage.get_stage_executions_for_run(run.id, StageType.EXPLORATION)
+        assert any(s.status == StageStatus.COMPLETED for s in old_stages)
+
+    def test_checkpoint_events_in_conversation(self):
+        """Verify checkpoint and transition events appear in conversation."""
+        storage = InMemoryStorage()
+        transport = InMemoryTransport()
+        state_machine = DiscoveryStateMachine(storage=storage)
+        service = ConversationService(
+            transport=transport, storage=storage, state_machine=state_machine
+        )
+
+        run = state_machine.create_run()
+        run = state_machine.start_run(run.id)
+        active = storage.get_active_stage(run.id)
+        convo_id = service.create_stage_conversation(run.id, active.id)
+
+        explorer = _make_explorer_with_findings()
+        result = explorer.explore()
+        checkpoint = explorer.build_checkpoint_artifacts(result)
+
+        service.submit_checkpoint(convo_id, run.id, "codebase", artifacts=checkpoint)
+
+        # Read conversation history
+        history = service.read_history(convo_id)
+        event_types = [e.event_type for e in history]
+
+        assert EventType.CHECKPOINT_SUBMIT in event_types
+        assert EventType.STAGE_TRANSITION in event_types
+
+    def test_empty_findings_checkpoint_still_advances(self):
+        """Explorer with zero findings should still produce a valid checkpoint."""
+        storage = InMemoryStorage()
+        transport = InMemoryTransport()
+        state_machine = DiscoveryStateMachine(storage=storage)
+        service = ConversationService(
+            transport=transport, storage=storage, state_machine=state_machine
+        )
+
+        run = state_machine.create_run()
+        run = state_machine.start_run(run.id)
+        active = storage.get_active_stage(run.id)
+        convo_id = service.create_stage_conversation(run.id, active.id)
+
+        # Explorer with no findings
+        explorer = _make_explorer_with_findings(findings=[])
+        result = explorer.explore()
+        checkpoint = explorer.build_checkpoint_artifacts(result)
+
+        # Should still validate and advance
+        new_stage = service.submit_checkpoint(
+            convo_id, run.id, "codebase", artifacts=checkpoint
+        )
+        assert new_stage.stage == StageType.OPPORTUNITY_FRAMING
+
+
+# ============================================================================
+# Requery flow
+# ============================================================================
+
+
+@pytest.mark.slow
+class TestCodebaseRequeryFlow:
+    def test_requery_through_conversation(self):
+        """Post explorer:request → explorer reads → responds with explorer:response."""
+        storage = InMemoryStorage()
+        transport = InMemoryTransport()
+        state_machine = DiscoveryStateMachine(storage=storage)
+        service = ConversationService(
+            transport=transport, storage=storage, state_machine=state_machine
+        )
+
+        run = state_machine.create_run()
+        run = state_machine.start_run(run.id)
+        active = storage.get_active_stage(run.id)
+        convo_id = service.create_stage_conversation(run.id, active.id)
+
+        # Post an explorer:request event
+        service.post_event(
+            convo_id,
+            "orchestrator",
+            EventType.EXPLORER_REQUEST,
+            {"query": "What tech debt patterns did you find?"},
+        )
+
+        # Explorer reads history and finds the request
+        history = service.read_history(convo_id)
+        requests = [e for e in history if e.event_type == EventType.EXPLORER_REQUEST]
+        assert len(requests) == 1
+
+        # Explorer handles the requery
+        items = [_make_codebase_item()]
+        reader = MockCodebaseReader(items=items)
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response({
+            "answer": "I found 3 inconsistent error handling patterns",
+            "evidence_file_paths": ["src/api/main.py"],
+            "confidence": "high",
+            "additional_findings": [],
+        })
+
+        explorer = CodebaseExplorer(reader=reader, openai_client=mock_client)
+        requery_result = explorer.requery(
+            request_text="What tech debt patterns did you find?",
+            previous_findings=[],
+            file_paths=["src/api/main.py"],
+        )
+
+        # Post the response back
+        service.post_event(
+            convo_id,
+            "codebase",
+            EventType.EXPLORER_RESPONSE,
+            {"answer": requery_result["answer"]},
+        )
+
+        # Verify response in history
+        history = service.read_history(convo_id)
+        responses = [e for e in history if e.event_type == EventType.EXPLORER_RESPONSE]
+        assert len(responses) == 1
+        assert "error handling" in responses[0].payload.get("answer", "")
+
+
+# ============================================================================
+# Taxonomy guard
+# ============================================================================
+
+
+# The 8 pipeline ConversationType values that the explorer should NOT use
+PIPELINE_TAXONOMY = {
+    "product_issue",
+    "how_to_question",
+    "feature_request",
+    "account_issue",
+    "billing_question",
+    "configuration_help",
+    "general_inquiry",
+    "spam",
+}
+
+# Pipeline-specific field names
+PIPELINE_FIELDS = {
+    "issue_signature",
+    "conversation_type",
+    "stage1_type",
+    "stage2_type",
+    "churn_risk",
+}
+
+
+@pytest.mark.slow
+class TestCodebaseTaxonomyGuard:
+    """Lightweight keyword check to enforce the 'no theme vocabulary' constraint.
+
+    These tests verify that the codebase explorer's artifact output doesn't
+    contain prohibited terms from the existing pipeline vocabulary.
+    """
+
+    def test_findings_dont_use_pipeline_categories(self):
+        """Explorer pattern names should not match pipeline ConversationType values."""
+        explorer = _make_explorer_with_findings(findings=[
+            {
+                "pattern_name": "inconsistent_error_handling",
+                "description": "Error handling varies across endpoints",
+                "evidence_file_paths": ["src/api/main.py"],
+                "confidence": "high",
+                "severity_assessment": "moderate",
+                "affected_users_estimate": "~30%",
+            },
+            {
+                "pattern_name": "duplicated_validation_logic",
+                "description": "Same validation in multiple places",
+                "evidence_file_paths": ["src/api/routes.py"],
+                "confidence": "medium",
+                "severity_assessment": "high",
+                "affected_users_estimate": "~15%",
+            },
+        ])
+
+        result = explorer.explore()
+        checkpoint = explorer.build_checkpoint_artifacts(result)
+
+        for finding in checkpoint["findings"]:
+            pattern = finding["pattern_name"].lower()
+            for prohibited in PIPELINE_TAXONOMY:
+                assert pattern != prohibited, (
+                    f"Explorer pattern_name '{pattern}' matches prohibited "
+                    f"pipeline category '{prohibited}'"
+                )
+
+    def test_checkpoint_doesnt_contain_pipeline_fields(self):
+        """Checkpoint artifacts should not contain pipeline-specific field names."""
+        explorer = _make_explorer_with_findings()
+        result = explorer.explore()
+        checkpoint = explorer.build_checkpoint_artifacts(result)
+
+        for field_name in PIPELINE_FIELDS:
+            if field_name == "conversation_type":
+                assert field_name not in checkpoint, (
+                    f"Pipeline field '{field_name}' found in checkpoint top-level keys"
+                )


### PR DESCRIPTION
## Summary

- Adds **CodebaseExplorer** agent for Stage 0 source code analysis in the Discovery Engine
- **CodebaseReader** data access layer reads recently-changed files via `git log` with scope/extension filtering
- Two-pass LLM strategy (per-batch analysis + synthesis) matching the CustomerVoiceExplorer pattern
- Produces `ExplorerCheckpoint` artifacts that integrate with the existing state machine
- Requery support for follow-up questions about specific source files

## Files

| File | Purpose |
|------|---------|
| `src/discovery/agents/codebase_data_access.py` | CodebaseReader + CodebaseItem |
| `src/discovery/agents/codebase_explorer.py` | CodebaseExplorer with explore/requery/checkpoint |
| `src/discovery/agents/prompts.py` | 6 new prompt constants for codebase analysis |
| `tests/discovery/test_codebase_explorer.py` | 33 unit tests |
| `tests/discovery/test_codebase_explorer_integration.py` | 6 integration tests (state machine flow) |
| `docs/plans/codebase-explorer-217-plan.md` | Implementation plan (reviewed via agenterminal) |

## Test plan

- [x] 39 new tests pass (33 unit + 6 integration)
- [x] 297 total discovery tests pass (0 regressions)
- [x] Coverage invariant: `reviewed + skipped == available`
- [x] Checkpoint validates against ExplorerCheckpoint model
- [x] State machine advances EXPLORATION → OPPORTUNITY_FRAMING
- [x] Taxonomy guard: no pipeline vocabulary in explorer output
- [ ] Code review via agenterminal

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)