### PR TITLE
Fix #235: Add artifact models for remaining discovery stages

### DIFF
--- a/src/discovery/models/enums.py
+++ b/src/discovery/models/enums.py
@@ -96,3 +96,13 @@ class BuildExperimentDecision(str, Enum):
     BUILD_SLICE_AND_EXPERIMENT = "build_slice_and_experiment"
     BUILD_WITH_METRICS = "build_with_metrics"
     BUILD_DIRECT = "build_direct"
+
+
+class ReviewDecisionType(str, Enum):
+    """Stage 5 Human Review decision types from #223."""
+
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    DEFERRED = "deferred"
+    SENT_BACK = "sent_back"
+    PRIORITY_ADJUSTED = "priority_adjusted"

--- a/src/discovery/services/conversation.py
+++ b/src/discovery/services/conversation.py
@@ -17,7 +17,9 @@ from pydantic import BaseModel, ValidationError
 from src.discovery.db.storage import DiscoveryStorage
 from src.discovery.models.artifacts import (
     ExplorerCheckpoint,
+    HumanReviewCheckpoint,
     OpportunityFramingCheckpoint,
+    PrioritizationCheckpoint,
     SolutionValidationCheckpoint,
     TechnicalSpec,
 )
@@ -43,8 +45,8 @@ STAGE_ARTIFACT_MODELS: Dict[StageType, Optional[Type[BaseModel]]] = {
     StageType.OPPORTUNITY_FRAMING: OpportunityFramingCheckpoint,  # Issue #219: wrapper for multiple briefs
     StageType.SOLUTION_VALIDATION: SolutionValidationCheckpoint,
     StageType.FEASIBILITY_RISK: TechnicalSpec,
-    StageType.PRIORITIZATION: None,  # Phase 1: no formal schema yet
-    StageType.HUMAN_REVIEW: None,  # Human decisions, no fixed schema
+    StageType.PRIORITIZATION: PrioritizationCheckpoint,  # Issue #235
+    StageType.HUMAN_REVIEW: HumanReviewCheckpoint,  # Issue #235
 }
 
 
@@ -357,8 +359,8 @@ class ConversationService:
     ) -> None:
         """Validate artifacts against the stage-specific Pydantic model.
 
-        Stages without a specific model (exploration, prioritization,
-        human_review) accept any non-empty dict.
+        All stages now have artifact models registered in STAGE_ARTIFACT_MODELS.
+        If a stage were mapped to None, it would accept any non-empty dict.
 
         Raises ArtifactValidationError on validation failure.
         """

--- a/tests/discovery/test_conversation_events.py
+++ b/tests/discovery/test_conversation_events.py
@@ -445,3 +445,77 @@ class TestArtifactValidation:
         }
         # Should not raise
         svc._validate_artifacts(StageType.OPPORTUNITY_FRAMING, artifacts)
+
+    def test_prioritization_valid(self):
+        from src.discovery.services.conversation import ConversationService
+        from src.discovery.services.transport import InMemoryTransport
+
+        svc = ConversationService(
+            transport=InMemoryTransport(),
+            storage=None,
+            state_machine=None,
+        )
+        artifacts = {
+            "rankings": [
+                {
+                    "opportunity_id": "opp_1",
+                    "recommended_rank": 1,
+                    "rationale": "High impact, low effort",
+                },
+            ],
+            "prioritization_metadata": {
+                "opportunities_ranked": 1,
+                "model": "gpt-4o-mini",
+            },
+        }
+        svc._validate_artifacts(StageType.PRIORITIZATION, artifacts)
+
+    def test_prioritization_rejects_invalid(self):
+        from src.discovery.services.conversation import ConversationService
+        from src.discovery.services.transport import InMemoryTransport
+
+        svc = ConversationService(
+            transport=InMemoryTransport(),
+            storage=None,
+            state_machine=None,
+        )
+        # Missing prioritization_metadata
+        with pytest.raises(ArtifactValidationError, match="Field required"):
+            svc._validate_artifacts(StageType.PRIORITIZATION, {"rankings": []})
+
+    def test_human_review_valid(self):
+        from src.discovery.services.conversation import ConversationService
+        from src.discovery.services.transport import InMemoryTransport
+
+        svc = ConversationService(
+            transport=InMemoryTransport(),
+            storage=None,
+            state_machine=None,
+        )
+        artifacts = {
+            "decisions": [
+                {
+                    "opportunity_id": "opp_1",
+                    "decision": "accepted",
+                    "reasoning": "High confidence, team ready",
+                },
+            ],
+            "review_metadata": {
+                "reviewer": "paul",
+                "opportunities_reviewed": 1,
+            },
+        }
+        svc._validate_artifacts(StageType.HUMAN_REVIEW, artifacts)
+
+    def test_human_review_rejects_invalid(self):
+        from src.discovery.services.conversation import ConversationService
+        from src.discovery.services.transport import InMemoryTransport
+
+        svc = ConversationService(
+            transport=InMemoryTransport(),
+            storage=None,
+            state_machine=None,
+        )
+        # Missing review_metadata
+        with pytest.raises(ArtifactValidationError, match="Field required"):
+            svc._validate_artifacts(StageType.HUMAN_REVIEW, {"decisions": []})

--- a/tests/discovery/test_conversation_service.py
+++ b/tests/discovery/test_conversation_service.py
@@ -588,7 +588,19 @@ class TestCompleteWithCheckpoint:
         StageType.OPPORTUNITY_FRAMING: _valid_opportunity_brief(),
         StageType.SOLUTION_VALIDATION: _valid_solution_brief(),
         StageType.FEASIBILITY_RISK: _valid_technical_spec(),
-        StageType.PRIORITIZATION: {"ranking": [1, 2, 3], "rationale": "impact"},
+        StageType.PRIORITIZATION: {
+            "rankings": [
+                {
+                    "opportunity_id": "opp_1",
+                    "recommended_rank": 1,
+                    "rationale": "High impact, low effort",
+                },
+            ],
+            "prioritization_metadata": {
+                "opportunities_ranked": 1,
+                "model": "gpt-4o-mini",
+            },
+        },
     }
 
     def _advance_to_human_review(self, service, storage, run_id):
@@ -617,7 +629,19 @@ class TestCompleteWithCheckpoint:
             convo_id,
             running_run.id,
             "human_reviewer",
-            artifacts={"decision": "approved", "notes": "Ship it"},
+            artifacts={
+                "decisions": [
+                    {
+                        "opportunity_id": "opp_1",
+                        "decision": "accepted",
+                        "reasoning": "High confidence, team ready",
+                    },
+                ],
+                "review_metadata": {
+                    "reviewer": "paul",
+                    "opportunities_reviewed": 1,
+                },
+            },
         )
 
         assert completed.status == RunStatus.COMPLETED
@@ -639,7 +663,19 @@ class TestCompleteWithCheckpoint:
                 "wrong-convo",
                 running_run.id,
                 "reviewer",
-                artifacts={"decision": "approved"},
+                artifacts={
+                    "decisions": [
+                        {
+                            "opportunity_id": "opp_1",
+                            "decision": "accepted",
+                            "reasoning": "Ship it",
+                        },
+                    ],
+                    "review_metadata": {
+                        "reviewer": "paul",
+                        "opportunities_reviewed": 1,
+                    },
+                },
             )
 
 


### PR DESCRIPTION
## Summary
- Adds `PrioritizationCheckpoint` (Stage 4) and `HumanReviewCheckpoint` (Stage 5) Pydantic models
- Adds `ReviewDecisionType` enum with conditional validation (`adjusted_priority` IFF `PRIORITY_ADJUSTED`, `send_back_to_stage` IFF `SENT_BACK`)
- Updates `STAGE_ARTIFACT_MODELS` — all 6 stages now have formal Pydantic validation
- 488 discovery tests passing (51 new)

## Test plan
- [x] 51 new artifact model tests (valid, invalid, conditional, extra fields)
- [x] 4 new conversation service validation tests (PRIORITIZATION + HUMAN_REVIEW valid/invalid)
- [x] Updated existing conversation service tests to use valid artifacts
- [x] Full discovery suite: 488 passed

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)