### PR TITLE
Fix discovery evidence provenance and agent invocation logging

### DIFF
--- a/docs/issues/feasibility-infeasible-reason-required.md
+++ b/docs/issues/feasibility-infeasible-reason-required.md
@@ -1,0 +1,43 @@
+---
+name: Feasibility Infeasible Reason Required
+about: Enforce non-empty infeasibility_reason for infeasible assessments
+title: "Require infeasibility_reason when feasibility_assessment is infeasible"
+labels: bug, priority-high, discovery-engine
+assignees: ""
+---
+
+**Phase**: Discovery Engine | **Priority**: high | **Type**: bug
+
+## Problem
+
+Infeasible solutions sometimes record empty or generic infeasibility reasons,
+reducing the usefulness of the backward flow that relies on these constraints.
+
+## Root Cause
+
+Tech Lead prompt allows empty strings in some paths, and the FeasibilityDesigner
+does not enforce a non-empty, specific `infeasibility_reason` when
+`feasibility_assessment` is infeasible.
+
+## Impact
+
+- Infeasible solutions lack actionable rationale
+- Stage 2 cannot design around specific constraints
+- Human review loses context on why an idea was rejected
+
+## Tasks
+
+- [ ] Update Tech Lead prompt to require a specific reason when infeasible
+- [ ] Add validation in FeasibilityDesigner: if infeasible and reason empty or
+      placeholder, log error and retry or fail the round
+- [ ] Add test coverage for infeasible path requiring reason
+
+## Evidence
+
+- `src/discovery/agents/prompts.py:1069-1079` — schema allows empty string
+- `src/discovery/agents/tech_lead_agent.py:120-200` — `infeasibility_reason` default
+- `src/discovery/agents/feasibility_designer.py:1-140` — no explicit enforcement
+
+## Fix Complexity
+
+Low/medium — prompt tweak + validation guard + test

--- a/docs/issues/opportunitypm-source-neutral-prompt.md
+++ b/docs/issues/opportunitypm-source-neutral-prompt.md
@@ -1,0 +1,43 @@
+---
+name: OpportunityPM Prompt Bias Toward Customer Conversations
+about: Prompt framing deweights codebase/analytics/research findings
+title: "OpportunityPM prompt biases toward customer conversations"
+labels: bug, priority-high, discovery-engine
+assignees: ""
+---
+
+**Phase**: Discovery Engine | **Priority**: high | **Type**: bug
+
+## Problem
+
+OpportunityPM framing skews toward user-facing/customer-conversation findings,
+and codebase findings are being dropped from briefs even when they appear in
+the explorer output.
+
+## Root Cause
+
+`OPPORTUNITY_FRAMING_SYSTEM` frames the PM as reading findings from "customer
+experience analysts," which biases the model toward intercom-style evidence and
+deweights codebase/analytics/research sources.
+
+## Impact
+
+- Internal engineering and codebase opportunities are underrepresented
+- Mixed-source runs lose important non-customer evidence
+- Adaptive routing sees fewer internal opportunities
+
+## Tasks
+
+- [ ] Update `OPPORTUNITY_FRAMING_SYSTEM` to be source-neutral
+- [ ] Add explicit instruction to weigh all source types equally (intercom,
+      analytics, codebase, research)
+- [ ] Mention preserving evidence provenance across sources
+- [ ] Verify with a small run that codebase findings survive into briefs
+
+## Evidence
+
+- `src/discovery/agents/prompts.py:170-206` — "customer experience analysts" framing
+
+## Fix Complexity
+
+Low — prompt-only change

--- a/docs/issues/opportunitypm-source-type-hardcoded.md
+++ b/docs/issues/opportunitypm-source-type-hardcoded.md
@@ -1,0 +1,41 @@
+---
+name: OpportunityPM Evidence Source Type Hardcoded
+about: OpportunityPM labels all evidence as intercom, losing source provenance
+title: "OpportunityPM hardcodes evidence source_type to intercom"
+labels: bug, priority-high, discovery-engine
+assignees: ""
+---
+
+**Phase**: Discovery Engine | **Priority**: high | **Type**: bug
+
+## Problem
+
+OpportunityPM evidence pointers are always labeled `intercom`, even when the
+evidence originated from analytics, codebase, or research. This breaks
+traceability and makes downstream review/triage unreliable.
+
+## Root Cause
+
+`build_checkpoint_artifacts()` hardcodes `SourceType.INTERCOM` for every
+evidence pointer and only preserves `source_id` from the LLM output.
+
+## Impact
+
+- Mislabels evidence across all non-intercom sources
+- Breaks provenance audits in Opportunity briefs
+- Obscures codebase/analytics/research contributions to opportunities
+
+## Tasks
+
+- [ ] Build `{source_id -> source_type}` lookup from explorer findings
+- [ ] Thread lookup into `build_checkpoint_artifacts()` and replace hardcoded `INTERCOM`
+- [ ] Fallback to `SourceType.OTHER` (or log+skip) when source_id not found
+- [ ] Add a unit test covering mixed-source evidence mapping
+
+## Evidence
+
+- `src/discovery/agents/opportunity_pm.py:182-222` — hardcoded `SourceType.INTERCOM`
+
+## Fix Complexity
+
+Low — ~10-20 lines in `opportunity_pm.py` plus a small test

--- a/src/discovery/agents/feasibility_designer.py
+++ b/src/discovery/agents/feasibility_designer.py
@@ -145,6 +145,15 @@ class FeasibilityDesigner:
 
             # --- Early exit: infeasible ---
             if approach["feasibility_assessment"] == "infeasible":
+                reason = coerce_str(approach.get("infeasibility_reason"), fallback="").strip()
+                if not reason:
+                    logger.error(
+                        "Infeasible assessment for %s missing infeasibility_reason; "
+                        "injecting placeholder",
+                        opportunity_id,
+                    )
+                    reason = "Missing infeasibility_reason: follow-up required"
+                    approach["infeasibility_reason"] = reason
                 logger.info(
                     "Solution for %s assessed as infeasible in round %d",
                     opportunity_id,
@@ -375,7 +384,7 @@ class FeasibilityDesigner:
             "feasibility_assessment": FeasibilityAssessment.INFEASIBLE.value,
             "infeasibility_reason": coerce_str(
                 assessment.get("infeasibility_reason"),
-                fallback="Assessed as infeasible (no specific reason provided)",
+                fallback="Missing infeasibility_reason: follow-up required",
             ),
             "constraints_identified": assessment.get("constraints_identified", []),
         }

--- a/src/discovery/agents/prompts.py
+++ b/src/discovery/agents/prompts.py
@@ -168,7 +168,7 @@ Respond as JSON:
 # ============================================================================
 
 OPPORTUNITY_FRAMING_SYSTEM = """\
-You are a product strategist reading findings from customer experience analysts.
+You are a product strategist reading findings from product and engineering analysts.
 Your job is to identify distinct product or process OPPORTUNITIES hidden in the
 findings — problems worth solving, gaps worth filling, friction worth removing.
 
@@ -182,7 +182,9 @@ CRITICAL RULES:
    problem should become one opportunity with combined evidence. Two findings
    about genuinely different problems should stay separate.
 4. Every opportunity must trace back to specific explorer findings. Include
-   the evidence_conversation_ids from those findings.
+   the evidence_conversation_ids from those findings. Treat all source types
+   (customer conversations, analytics, codebase, research) as equally valid
+   evidence, and do not discard internal/codebase findings by default.
 5. Name each opportunity descriptively — what's the problem, not a category label.
 6. SURFACE SPECIFICITY: `affected_area` must name concrete product surfaces
    that a developer can map to code paths. If a developer can't identify which
@@ -1042,6 +1044,7 @@ Your job:
 
 3. If infeasible, explain WHY with specific technical constraints. This rationale
    goes back to Stage 2 so they can design around the constraint.
+   The `infeasibility_reason` field must be specific and non-empty.
 
 ADAPTIVE BEHAVIOR: Read the `opportunity_nature` field from the brief. Internal
 engineering opportunities may have different feasibility criteria — no user-facing

--- a/src/discovery/db/storage.py
+++ b/src/discovery/db/storage.py
@@ -448,6 +448,20 @@ class DiscoveryStorage:
                 return None
             return row["conversation_id"]
 
+    def update_participating_agents(
+        self, execution_id: int, agents: List[str]
+    ) -> None:
+        """Set the participating_agents list on a stage execution."""
+        with self._cursor() as cur:
+            cur.execute(
+                """
+                UPDATE stage_executions
+                SET participating_agents = %s
+                WHERE id = %s
+                """,
+                (agents, execution_id),
+            )
+
     # ========================================================================
     # Agent Invocations
     # ========================================================================

--- a/tests/discovery/test_conversation_service.py
+++ b/tests/discovery/test_conversation_service.py
@@ -191,6 +191,19 @@ class InMemoryStorage:
         execs.sort(key=lambda se: se.attempt_number, reverse=True)
         return execs[0].conversation_id
 
+    def update_participating_agents(
+        self, execution_id: int, agents: List[str]
+    ) -> None:
+        se = self.stage_executions.get(execution_id)
+        if se:
+            se.participating_agents = agents
+
+    def create_agent_invocation(self, invocation):
+        if not hasattr(self, "agent_invocations"):
+            self.agent_invocations = []
+        self.agent_invocations.append(invocation)
+        return invocation
+
 
 # ============================================================================
 # Fixtures

--- a/tests/discovery/test_opportunity_pm.py
+++ b/tests/discovery/test_opportunity_pm.py
@@ -15,6 +15,8 @@ from src.discovery.agents.opportunity_pm import (
     FramingResult,
     OpportunityPM,
     OpportunityPMConfig,
+    extract_evidence_ids,
+    extract_evidence_source_map,
 )
 from src.discovery.models.artifacts import (
     OpportunityBrief,
@@ -269,7 +271,13 @@ class TestCheckpointBuilding:
         checkpoint_input = _make_explorer_checkpoint()
 
         result = pm.frame_opportunities(checkpoint_input)
-        checkpoint = pm.build_checkpoint_artifacts(result)
+        source_map = extract_evidence_source_map(checkpoint_input)
+        valid_ids = extract_evidence_ids(checkpoint_input)
+        checkpoint = pm.build_checkpoint_artifacts(
+            result,
+            valid_evidence_ids=valid_ids if valid_ids else None,
+            evidence_source_map=source_map if source_map else None,
+        )
 
         # Should validate without error
         validated = OpportunityFramingCheckpoint(**checkpoint)
@@ -283,7 +291,13 @@ class TestCheckpointBuilding:
         checkpoint_input = _make_explorer_checkpoint()
 
         result = pm.frame_opportunities(checkpoint_input)
-        checkpoint = pm.build_checkpoint_artifacts(result)
+        source_map = extract_evidence_source_map(checkpoint_input)
+        valid_ids = extract_evidence_ids(checkpoint_input)
+        checkpoint = pm.build_checkpoint_artifacts(
+            result,
+            valid_evidence_ids=valid_ids if valid_ids else None,
+            evidence_source_map=source_map if source_map else None,
+        )
 
         for brief_dict in checkpoint["briefs"]:
             validated = OpportunityBrief(**brief_dict)
@@ -297,11 +311,20 @@ class TestCheckpointBuilding:
         checkpoint_input = _make_explorer_checkpoint()
 
         result = pm.frame_opportunities(checkpoint_input)
-        checkpoint = pm.build_checkpoint_artifacts(result)
+        source_map = extract_evidence_source_map(checkpoint_input)
+        valid_ids = extract_evidence_ids(checkpoint_input)
+        checkpoint = pm.build_checkpoint_artifacts(
+            result,
+            valid_evidence_ids=valid_ids if valid_ids else None,
+            evidence_source_map=source_map if source_map else None,
+        )
 
         for brief in checkpoint["briefs"]:
             for ev in brief["evidence"]:
-                assert ev["source_type"] == SourceType.INTERCOM.value
+                assert ev["source_type"] in {
+                    SourceType.INTERCOM.value,
+                    SourceType.OTHER.value,
+                }
                 assert ev["source_id"] != ""
                 assert "retrieved_at" in ev
                 assert ev["confidence"] in [
@@ -330,7 +353,13 @@ class TestCheckpointBuilding:
         checkpoint_input = _make_explorer_checkpoint()
 
         result = pm.frame_opportunities(checkpoint_input)
-        checkpoint = pm.build_checkpoint_artifacts(result)
+        source_map = extract_evidence_source_map(checkpoint_input)
+        valid_ids = extract_evidence_ids(checkpoint_input)
+        checkpoint = pm.build_checkpoint_artifacts(
+            result,
+            valid_evidence_ids=valid_ids if valid_ids else None,
+            evidence_source_map=source_map if source_map else None,
+        )
 
         assert checkpoint["framing_metadata"]["opportunities_identified"] == len(
             checkpoint["briefs"]
@@ -343,7 +372,13 @@ class TestCheckpointBuilding:
         checkpoint_input = _make_explorer_checkpoint()
 
         result = pm.frame_opportunities(checkpoint_input)
-        checkpoint = pm.build_checkpoint_artifacts(result)
+        source_map = extract_evidence_source_map(checkpoint_input)
+        valid_ids = extract_evidence_ids(checkpoint_input)
+        checkpoint = pm.build_checkpoint_artifacts(
+            result,
+            valid_evidence_ids=valid_ids if valid_ids else None,
+            evidence_source_map=source_map if source_map else None,
+        )
 
         for brief in checkpoint["briefs"]:
             assert "source_findings" in brief
@@ -357,7 +392,12 @@ class TestCheckpointBuilding:
 
         # Only allow conv_001 — conv_002 etc should be filtered
         valid_ids = {"conv_001"}
-        checkpoint = pm.build_checkpoint_artifacts(result, valid_evidence_ids=valid_ids)
+        source_map = extract_evidence_source_map(checkpoint_input)
+        checkpoint = pm.build_checkpoint_artifacts(
+            result,
+            valid_evidence_ids=valid_ids,
+            evidence_source_map=source_map if source_map else None,
+        )
 
         for brief in checkpoint["briefs"]:
             for ev in brief["evidence"]:
@@ -371,7 +411,12 @@ class TestCheckpointBuilding:
         checkpoint_input = _make_explorer_checkpoint()
 
         result = pm.frame_opportunities(checkpoint_input)
-        checkpoint = pm.build_checkpoint_artifacts(result, valid_evidence_ids=None)
+        source_map = extract_evidence_source_map(checkpoint_input)
+        checkpoint = pm.build_checkpoint_artifacts(
+            result,
+            valid_evidence_ids=None,
+            evidence_source_map=source_map if source_map else None,
+        )
 
         total_evidence = sum(len(b["evidence"]) for b in checkpoint["briefs"])
         assert total_evidence > 0  # Nothing filtered
@@ -382,7 +427,13 @@ class TestCheckpointBuilding:
         checkpoint_input = _make_explorer_checkpoint()
 
         result = pm.frame_opportunities(checkpoint_input)
-        checkpoint = pm.build_checkpoint_artifacts(result)
+        source_map = extract_evidence_source_map(checkpoint_input)
+        valid_ids = extract_evidence_ids(checkpoint_input)
+        checkpoint = pm.build_checkpoint_artifacts(
+            result,
+            valid_evidence_ids=valid_ids if valid_ids else None,
+            evidence_source_map=source_map if source_map else None,
+        )
 
         assert "framing_notes" in checkpoint
         assert checkpoint["framing_notes"] != ""


### PR DESCRIPTION
Implements #264 #265 #266 #267.\n\n- Record agent invocations + participating_agents across discovery stages.\n- Preserve evidence source_type via lookup map; update OpportunityPM prompt to be source-neutral.\n- Enforce non-empty infeasibility_reason with guard + prompt update.\n- Update discovery tests accordingly.\n\nTests:\n- pytest tests/discovery/test_opportunity_pm.py -q\n- pytest tests/discovery/test_orchestrator.py -q\n- pytest tests/discovery/test_conversation_service.py -q