### PR TITLE
feat: InputRejection and InputValidationResult models + validation prompts

### DIFF
--- a/src/discovery/models/conversation.py
+++ b/src/discovery/models/conversation.py
@@ -31,6 +31,7 @@ class EventType(str, Enum):
     EXPLORER_RESPONSE = "explorer:response"
     CHECKPOINT_SUBMIT = "checkpoint:submit"
     STAGE_TRANSITION = "stage:transition"
+    INPUT_VALIDATION = "input:validation"
 
 
 class ConversationTurn(BaseModel):

--- a/src/discovery/services/state_machine.py
+++ b/src/discovery/services/state_machine.py
@@ -65,6 +65,8 @@ VALID_STAGE_TRANSITIONS = {
 ALLOWED_BACKWARD_TRANSITIONS = {
     StageType.FEASIBILITY_RISK: {StageType.SOLUTION_VALIDATION},
     StageType.HUMAN_REVIEW: set(STAGE_ORDER),  # can send back to any stage
+    StageType.SOLUTION_VALIDATION: {StageType.OPPORTUNITY_FRAMING},  # input validation rejection
+    StageType.PRIORITIZATION: {StageType.FEASIBILITY_RISK},  # input validation rejection
 }
 
 


### PR DESCRIPTION
## Summary

Adds foundation models, prompts, event types, and state machine transitions for receiving-stage input validation in the discovery pipeline (#275).

- **New models**: `InputRejection` and `InputValidationResult` Pydantic models in `src/discovery/models/artifacts.py`
- **New field**: `validation_warnings: Optional[List[str]]` on `OpportunityBrief`, `SolutionBrief`, `TechnicalSpec`
- **New prompts**: 6 prompt pairs (3 validation + 3 revision) in `src/discovery/agents/prompts.py`
- **Prompt cleanup**: Removed self-check rules 8-9 from `OPPORTUNITY_FRAMING_SYSTEM` and `needs_decomposition` format from `OPPORTUNITY_FRAMING_USER` (moved to validation layer)
- **New event type**: `EventType.INPUT_VALIDATION` in conversation event system
- **New backward transitions**: `SOLUTION_VALIDATION→OPPORTUNITY_FRAMING` and `PRIORITIZATION→FEASIBILITY_RISK`
- **31 new tests** covering all acceptance criteria

## Test plan

- [x] `pytest tests/discovery/test_artifacts.py -k "input_rejection or input_validation_result or validation_warnings" -v` — 20 pass
- [x] `pytest tests/discovery/test_state_machine.py -k "backward_transition" -v` — 2 pass  
- [x] `pytest tests/discovery/test_conversation_events.py -k "input_validation or prompt" -v` — 9 pass
- [x] `pytest tests/discovery/ -m "fast"` — 691 pass, 0 fail
- [x] No changes to agent logic or orchestrator.py (guardrails respected)

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)